### PR TITLE
Sign-in fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ app/google-services.json
 .externalNativeBuild
 .cxx
 /app/.idea/
+app/local.properties
+app/src/main/java/com/github/wanderwise_inc/app/viewmodel/LoginViewModel.kt
+app/external/debug.keystore

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,6 +33,12 @@ android {
         }
     }
 
+    signingConfigs {
+        getByName("debug") {
+            storeFile = file("external/debug.keystore")
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -41,6 +47,7 @@ android {
                 "proguard-rules.pro"
             )
         }
+
 
         debug {
             enableUnitTestCoverage = true

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/signin/LoginScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/signin/LoginScreen.kt
@@ -134,7 +134,6 @@ fun SignInButton(
 
         if (user == null) {
             Log.d("USERS", "USER IS NULL")
-            navController.navigate(Graph.HOME)
             // TODO Handle ERROR
 
         } else {


### PR DESCRIPTION
previously was only working for @engjellismaili due to application signing using local `debug.keystore` which has now been taken into consideration in app-level `build.gradle.kts`.  Please place his keystore in
```
app/external/debug.keystore
```
for correct behavior

The previous "bandaid" fix (navigate even on sign-in failure) has been removed as it is no longer necessary