### PR TITLE
Added the filter of itinerary feature, to filter with regards of different items

### DIFF
--- a/app/src/main/java/com/github/wanderwise_inc/app/DemoSetup.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/DemoSetup.kt
@@ -77,6 +77,8 @@ fun addItineraries(mapViewModel: MapViewModel, profileViewModel: ProfileViewMode
                   ItineraryTags.WELLNESS),
           description = null,
           visible = true,
+          time = 3,
+          price = 25.0f,
       )
   val currentUser = FirebaseAuth.getInstance().currentUser
   val currentUserUid = currentUser?.uid ?: DEFAULT_USER_UID

--- a/app/src/main/java/com/github/wanderwise_inc/app/data/ItineraryRepository.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/data/ItineraryRepository.kt
@@ -32,7 +32,6 @@ interface ItineraryRepository {
 
   /** @brief deletes an itinerary */
   fun deleteItinerary(itinerary: Itinerary)
-
 }
 /**
  * const val ITINERARY_COLLECTION_PATH: String = "itineraries"

--- a/app/src/main/java/com/github/wanderwise_inc/app/data/ItineraryRepository.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/data/ItineraryRepository.kt
@@ -32,6 +32,7 @@ interface ItineraryRepository {
 
   /** @brief deletes an itinerary */
   fun deleteItinerary(itinerary: Itinerary)
+
 }
 /**
  * const val ITINERARY_COLLECTION_PATH: String = "itineraries"

--- a/app/src/main/java/com/github/wanderwise_inc/app/model/location/Itinerary.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/model/location/Itinerary.kt
@@ -13,6 +13,8 @@ object ItineraryLabels {
   const val DESCRIPTION = "description"
   const val VISIBLE = "visible"
   const val TAGS = "tags"
+  const val PRICE = "price"
+  const val TIME = "time"
 }
 
 /** @brief score of an itinerary based on some preferences */
@@ -36,7 +38,9 @@ data class Itinerary(
     var tags: List<Tag>,
     val description: String?,
     val visible: Boolean,
-    var numLikes: Int = 0
+    var numLikes: Int = 0,
+    val price: Float = 0f,
+    val time: Int = 0
 ) {
   /** @return a map representation of an itinerary */
   fun toMap(): Map<String, Any> {
@@ -48,6 +52,9 @@ data class Itinerary(
         ItineraryLabels.TAGS to tags,
         ItineraryLabels.DESCRIPTION to (description ?: ""),
         ItineraryLabels.VISIBLE to visible,
+        ItineraryLabels.PRICE to price,
+        ItineraryLabels.TIME to time
+
     )
   }
 
@@ -71,7 +78,9 @@ data class Itinerary(
       var title: String = "",
       val tags: MutableList<Tag> = mutableListOf(),
       var description: String? = null,
-      var visible: Boolean = false
+      var visible: Boolean = false,
+      val price: Float = 0f,
+      val time: Int = 0
   ) {
     /**
      * @param location the location to be added

--- a/app/src/main/java/com/github/wanderwise_inc/app/model/location/Itinerary.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/model/location/Itinerary.kt
@@ -53,9 +53,7 @@ data class Itinerary(
         ItineraryLabels.DESCRIPTION to (description ?: ""),
         ItineraryLabels.VISIBLE to visible,
         ItineraryLabels.PRICE to price,
-        ItineraryLabels.TIME to time
-
-    )
+        ItineraryLabels.TIME to time)
   }
 
   /*fun copy(): Itinerary {

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/home/SearchBar.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/home/SearchBar.kt
@@ -29,7 +29,7 @@ import com.github.wanderwise_inc.app.R
 fun SearchBar(
     onSearchChange: (String) -> Unit,
     onPriceChange: (Float) -> Unit,
-    sliderPositionState: MutableState<ClosedFloatingPointRange<Float>>,
+    sliderPositionPriceState: MutableState<ClosedFloatingPointRange<Float>>,
     sliderPositionTimeState: MutableState<ClosedFloatingPointRange<Float>>
 ) {
   var query by remember { mutableStateOf("") }
@@ -67,9 +67,9 @@ fun SearchBar(
       modifier = Modifier.fillMaxWidth()) {
         Text("How much do I want to spend ?")
         RangeSlider(
-            value = sliderPositionState.value,
+            value = sliderPositionPriceState.value,
             steps = 50,
-            onValueChange = { range -> sliderPositionState.value = range },
+            onValueChange = { range -> sliderPositionPriceState.value = range },
             valueRange = 0f..100f, // Adjust this range according to your needs
             onValueChangeFinished = {
               // launch something
@@ -79,8 +79,8 @@ fun SearchBar(
             text =
                 String.format(
                     "%.2f - %.2f",
-                    sliderPositionState.value.start,
-                    sliderPositionState.value.endInclusive))
+                    sliderPositionPriceState.value.start,
+                    sliderPositionPriceState.value.endInclusive))
         // sliderPosition.contains()
 
         Text("How Long do I want to wander ?")

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/home/SearchBar.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/home/SearchBar.kt
@@ -1,6 +1,5 @@
 package com.github.wanderwise_inc.app.ui.home
 
-import androidx.annotation.FloatRange
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -27,7 +26,12 @@ import androidx.compose.ui.unit.dp
 import com.github.wanderwise_inc.app.R
 
 @Composable
-fun SearchBar(onSearchChange: (String) -> Unit, onPriceChange: (Float) -> Unit, sliderPositionState : MutableState<ClosedFloatingPointRange<Float>>, sliderPositionTimeState : MutableState<ClosedFloatingPointRange<Float>>) {
+fun SearchBar(
+    onSearchChange: (String) -> Unit,
+    onPriceChange: (Float) -> Unit,
+    sliderPositionState: MutableState<ClosedFloatingPointRange<Float>>,
+    sliderPositionTimeState: MutableState<ClosedFloatingPointRange<Float>>
+) {
   var query by remember { mutableStateOf("") }
   var isDropdownOpen by remember { mutableStateOf(false) }
   var sliderPosition by remember { mutableStateOf(0f..100f) }
@@ -71,8 +75,13 @@ fun SearchBar(onSearchChange: (String) -> Unit, onPriceChange: (Float) -> Unit, 
               // launch something
             },
         )
-      Text(text = String.format("%.2f - %.2f", sliderPositionState.value.start, sliderPositionState.value.endInclusive))
-      //sliderPosition.contains()
+        Text(
+            text =
+                String.format(
+                    "%.2f - %.2f",
+                    sliderPositionState.value.start,
+                    sliderPositionState.value.endInclusive))
+        // sliderPosition.contains()
 
         Text("How Long do I want to wander ?")
         RangeSlider(
@@ -84,6 +93,11 @@ fun SearchBar(onSearchChange: (String) -> Unit, onPriceChange: (Float) -> Unit, 
               // launch something
             },
         )
-      Text(text = String.format("%.2f - %.2f", sliderPositionTimeState.value.start, sliderPositionTimeState.value.endInclusive))
+        Text(
+            text =
+                String.format(
+                    "%.2f - %.2f",
+                    sliderPositionTimeState.value.start,
+                    sliderPositionTimeState.value.endInclusive))
       }
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/home/SearchBar.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/home/SearchBar.kt
@@ -1,5 +1,6 @@
 package com.github.wanderwise_inc.app.ui.home
 
+import androidx.annotation.FloatRange
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,6 +14,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RangeSlider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -25,7 +27,7 @@ import androidx.compose.ui.unit.dp
 import com.github.wanderwise_inc.app.R
 
 @Composable
-fun SearchBar(onSearchChange: (String) -> Unit, onPriceChange: (Float) -> Unit) {
+fun SearchBar(onSearchChange: (String) -> Unit, onPriceChange: (Float) -> Unit, sliderPositionState : MutableState<ClosedFloatingPointRange<Float>>, sliderPositionTimeState : MutableState<ClosedFloatingPointRange<Float>>) {
   var query by remember { mutableStateOf("") }
   var isDropdownOpen by remember { mutableStateOf(false) }
   var sliderPosition by remember { mutableStateOf(0f..100f) }
@@ -61,26 +63,27 @@ fun SearchBar(onSearchChange: (String) -> Unit, onPriceChange: (Float) -> Unit) 
       modifier = Modifier.fillMaxWidth()) {
         Text("How much do I want to spend ?")
         RangeSlider(
-            value = sliderPosition,
+            value = sliderPositionState.value,
             steps = 50,
-            onValueChange = { range -> sliderPosition = range },
+            onValueChange = { range -> sliderPositionState.value = range },
             valueRange = 0f..100f, // Adjust this range according to your needs
             onValueChangeFinished = {
               // launch something
             },
         )
-        Text(text = sliderPosition.toString())
+      Text(text = String.format("%.2f - %.2f", sliderPositionState.value.start, sliderPositionState.value.endInclusive))
+      //sliderPosition.contains()
 
-        Text("How Long to I want to wander ?")
+        Text("How Long do I want to wander ?")
         RangeSlider(
-            value = sliderPositionTime,
+            value = sliderPositionTimeState.value,
             steps = 24,
-            onValueChange = { range -> sliderPositionTime = range },
+            onValueChange = { range -> sliderPositionTimeState.value = range },
             valueRange = 0f..24f, // Adjust this range according to your needs
             onValueChangeFinished = {
               // launch something
             },
         )
-        Text(text = sliderPositionTime.toString())
+      Text(text = String.format("%.2f - %.2f", sliderPositionState.value.start, sliderPositionState.value.endInclusive))
       }
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/home/SearchBar.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/home/SearchBar.kt
@@ -84,6 +84,6 @@ fun SearchBar(onSearchChange: (String) -> Unit, onPriceChange: (Float) -> Unit, 
               // launch something
             },
         )
-      Text(text = String.format("%.2f - %.2f", sliderPositionState.value.start, sliderPositionState.value.endInclusive))
+      Text(text = String.format("%.2f - %.2f", sliderPositionTimeState.value.start, sliderPositionTimeState.value.endInclusive))
       }
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
@@ -111,14 +111,14 @@ fun ItineraryBanner(
                           modifier = Modifier.padding(4.dp, 0.dp))
 
                       Text(
-                          text = "Estimated time : $times hours",
+                          text = "Estimated time: $times hours",
                           color = MaterialTheme.colorScheme.secondary,
                           fontFamily = FontFamily.Monospace,
                           fontSize = 12.sp,
                           modifier = Modifier.padding(4.dp, 0.dp))
 
                       Text(
-                          text = "Average Expense : $prices",
+                          text = "Average Expense: $prices",
                           color = MaterialTheme.colorScheme.secondary,
                           fontFamily = FontFamily.Monospace,
                           fontSize = 12.sp,

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -58,6 +59,8 @@ fun ItineraryBanner(
 
   var isLiked by remember { mutableStateOf(isLikedInitially) }
   var numLikes by remember { mutableIntStateOf(itinerary.numLikes) }
+  var prices by remember { mutableFloatStateOf(itinerary.price) }
+  var times by remember { mutableIntStateOf(itinerary.time) }
 
   ElevatedCard(
       colors =
@@ -108,14 +111,14 @@ fun ItineraryBanner(
                           modifier = Modifier.padding(4.dp, 0.dp))
 
                       Text(
-                          text = "Estimated time : - hours",
+                          text = "Estimated time : $times hours",
                           color = MaterialTheme.colorScheme.secondary,
                           fontFamily = FontFamily.Monospace,
                           fontSize = 12.sp,
                           modifier = Modifier.padding(4.dp, 0.dp))
 
                       Text(
-                          text = "Average Expense : -",
+                          text = "Average Expense : $prices",
                           color = MaterialTheme.colorScheme.secondary,
                           fontFamily = FontFamily.Monospace,
                           fontSize = 12.sp,

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/LikedScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/LikedScreen.kt
@@ -36,14 +36,23 @@ object LikedScreenTestTags {
 
 @Composable
 fun LikedScreen(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel) {
-    val sliderPositionState = remember { mutableStateOf(0f..100f)}
-    val sliderPositionTimeState = remember { mutableStateOf(0f..24f)}
-  DisplayLikedItineraries(mapViewModel = mapViewModel, profileViewModel = profileViewModel, sliderPositionState = sliderPositionState, sliderPositionTimeState = sliderPositionState)
+  val sliderPositionState = remember { mutableStateOf(0f..100f) }
+  val sliderPositionTimeState = remember { mutableStateOf(0f..24f) }
+  DisplayLikedItineraries(
+      mapViewModel = mapViewModel,
+      profileViewModel = profileViewModel,
+      sliderPositionState = sliderPositionState,
+      sliderPositionTimeState = sliderPositionState)
 }
 
 /** Displays itineraries liked by the user */
 @Composable
-fun DisplayLikedItineraries(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel, sliderPositionState: MutableState<ClosedFloatingPointRange<Float>>, sliderPositionTimeState: MutableState<ClosedFloatingPointRange<Float>>) {
+fun DisplayLikedItineraries(
+    mapViewModel: MapViewModel,
+    profileViewModel: ProfileViewModel,
+    sliderPositionState: MutableState<ClosedFloatingPointRange<Float>>,
+    sliderPositionTimeState: MutableState<ClosedFloatingPointRange<Float>>
+) {
 
   /* the categories that can be selected by the user during filtering */
   val categoriesList =
@@ -68,7 +77,11 @@ fun DisplayLikedItineraries(mapViewModel: MapViewModel, profileViewModel: Profil
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.fillMaxWidth().testTag(LikedScreenTestTags.CATEGORY_SELECTOR)) {
-              SearchBar(onSearchChange = { searchQuery = it }, onPriceChange = { priceRange = it }, sliderPositionState = sliderPositionState, sliderPositionTimeState = sliderPositionTimeState)
+              SearchBar(
+                  onSearchChange = { searchQuery = it },
+                  onPriceChange = { priceRange = it },
+                  sliderPositionState = sliderPositionState,
+                  sliderPositionTimeState = sliderPositionTimeState)
 
               CategorySelector(
                   selectedIndex = selectedIndex,
@@ -84,12 +97,17 @@ fun DisplayLikedItineraries(mapViewModel: MapViewModel, profileViewModel: Profil
                   searchQuery.isBlank() ||
                       itinerary.title.contains(searchQuery, ignoreCase = true) ||
                       itinerary.description?.contains(searchQuery, ignoreCase = true) ?: false
-                }.filter { itinerary ->
-                    val price = itinerary.price.toFloat()
-                    price in sliderPositionState.value.start..sliderPositionState.value.endInclusive
-                }.filter { itinerary ->
-                    val time = itinerary.time.toFloat()
-                    time in sliderPositionTimeState.value.start..sliderPositionTimeState.value.endInclusive }
+                }
+                .filter { itinerary ->
+                  val price = itinerary.price.toFloat()
+                  price in sliderPositionState.value.start..sliderPositionState.value.endInclusive
+                }
+                .filter { itinerary ->
+                  val time = itinerary.time.toFloat()
+                  time in
+                      sliderPositionTimeState.value.start..sliderPositionTimeState.value
+                              .endInclusive
+                }
         ItinerariesListScrollable(
             itineraries = filtered,
             paddingValues = innerPadding,

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/LikedScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/LikedScreen.kt
@@ -37,12 +37,13 @@ object LikedScreenTestTags {
 @Composable
 fun LikedScreen(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel) {
     val sliderPositionState = remember { mutableStateOf(0f..100f)}
-  DisplayLikedItineraries(mapViewModel = mapViewModel, profileViewModel = profileViewModel, sliderPositionState = sliderPositionState)
+    val sliderPositionTimeState = remember { mutableStateOf(0f..24f)}
+  DisplayLikedItineraries(mapViewModel = mapViewModel, profileViewModel = profileViewModel, sliderPositionState = sliderPositionState, sliderPositionTimeState = sliderPositionState)
 }
 
 /** Displays itineraries liked by the user */
 @Composable
-fun DisplayLikedItineraries(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel, sliderPositionState: MutableState<ClosedFloatingPointRange<Float>>) {
+fun DisplayLikedItineraries(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel, sliderPositionState: MutableState<ClosedFloatingPointRange<Float>>, sliderPositionTimeState: MutableState<ClosedFloatingPointRange<Float>>) {
 
   /* the categories that can be selected by the user during filtering */
   val categoriesList =
@@ -67,7 +68,7 @@ fun DisplayLikedItineraries(mapViewModel: MapViewModel, profileViewModel: Profil
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.fillMaxWidth().testTag(LikedScreenTestTags.CATEGORY_SELECTOR)) {
-              SearchBar(onSearchChange = { searchQuery = it }, onPriceChange = { priceRange = it }, sliderPositionState = sliderPositionState)
+              SearchBar(onSearchChange = { searchQuery = it }, onPriceChange = { priceRange = it }, sliderPositionState = sliderPositionState, sliderPositionTimeState = sliderPositionTimeState)
 
               CategorySelector(
                   selectedIndex = selectedIndex,
@@ -83,7 +84,12 @@ fun DisplayLikedItineraries(mapViewModel: MapViewModel, profileViewModel: Profil
                   searchQuery.isBlank() ||
                       itinerary.title.contains(searchQuery, ignoreCase = true) ||
                       itinerary.description?.contains(searchQuery, ignoreCase = true) ?: false
-                }
+                }.filter { itinerary ->
+                    val price = itinerary.price.toFloat()
+                    price in sliderPositionState.value.start..sliderPositionState.value.endInclusive
+                }.filter { itinerary ->
+                    val time = itinerary.time.toFloat()
+                    time in sliderPositionTimeState.value.start..sliderPositionTimeState.value.endInclusive }
         ItinerariesListScrollable(
             itineraries = filtered,
             paddingValues = innerPadding,

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/LikedScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/LikedScreen.kt
@@ -36,13 +36,13 @@ object LikedScreenTestTags {
 
 @Composable
 fun LikedScreen(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel) {
-  val sliderPositionState = remember { mutableStateOf(0f..100f) }
+  val sliderPositionPriceState = remember { mutableStateOf(0f..100f) }
   val sliderPositionTimeState = remember { mutableStateOf(0f..24f) }
   DisplayLikedItineraries(
       mapViewModel = mapViewModel,
       profileViewModel = profileViewModel,
-      sliderPositionState = sliderPositionState,
-      sliderPositionTimeState = sliderPositionState)
+      sliderPositionPriceState = sliderPositionPriceState,
+      sliderPositionTimeState = sliderPositionTimeState)
 }
 
 /** Displays itineraries liked by the user */
@@ -50,7 +50,7 @@ fun LikedScreen(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel) 
 fun DisplayLikedItineraries(
     mapViewModel: MapViewModel,
     profileViewModel: ProfileViewModel,
-    sliderPositionState: MutableState<ClosedFloatingPointRange<Float>>,
+    sliderPositionPriceState: MutableState<ClosedFloatingPointRange<Float>>,
     sliderPositionTimeState: MutableState<ClosedFloatingPointRange<Float>>
 ) {
 
@@ -80,7 +80,7 @@ fun DisplayLikedItineraries(
               SearchBar(
                   onSearchChange = { searchQuery = it },
                   onPriceChange = { priceRange = it },
-                  sliderPositionState = sliderPositionState,
+                  sliderPositionPriceState = sliderPositionPriceState,
                   sliderPositionTimeState = sliderPositionTimeState)
 
               CategorySelector(
@@ -100,7 +100,7 @@ fun DisplayLikedItineraries(
                 }
                 .filter { itinerary ->
                   val price = itinerary.price.toFloat()
-                  price in sliderPositionState.value.start..sliderPositionState.value.endInclusive
+                  price in sliderPositionPriceState.value.start..sliderPositionPriceState.value.endInclusive
                 }
                 .filter { itinerary ->
                   val time = itinerary.time.toFloat()

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/LikedScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/LikedScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -35,12 +36,13 @@ object LikedScreenTestTags {
 
 @Composable
 fun LikedScreen(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel) {
-  DisplayLikedItineraries(mapViewModel = mapViewModel, profileViewModel = profileViewModel)
+    val sliderPositionState = remember { mutableStateOf(0f..100f)}
+  DisplayLikedItineraries(mapViewModel = mapViewModel, profileViewModel = profileViewModel, sliderPositionState = sliderPositionState)
 }
 
 /** Displays itineraries liked by the user */
 @Composable
-fun DisplayLikedItineraries(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel) {
+fun DisplayLikedItineraries(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel, sliderPositionState: MutableState<ClosedFloatingPointRange<Float>>) {
 
   /* the categories that can be selected by the user during filtering */
   val categoriesList =
@@ -65,7 +67,7 @@ fun DisplayLikedItineraries(mapViewModel: MapViewModel, profileViewModel: Profil
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.fillMaxWidth().testTag(LikedScreenTestTags.CATEGORY_SELECTOR)) {
-              SearchBar(onSearchChange = { searchQuery = it }, onPriceChange = { priceRange = it })
+              SearchBar(onSearchChange = { searchQuery = it }, onPriceChange = { priceRange = it }, sliderPositionState = sliderPositionState)
 
               CategorySelector(
                   selectedIndex = selectedIndex,

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/OverviewScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/OverviewScreen.kt
@@ -24,12 +24,13 @@ import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
 @Composable
 fun OverviewScreen(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel) {
     val sliderPositionState = remember { mutableStateOf(0f..100f)}
-  DisplayOverviewItineraries(mapViewModel = mapViewModel, profileViewModel = profileViewModel, sliderPositionState = sliderPositionState)
+    val sliderPositionTimeState = remember { mutableStateOf(0f..24f)}
+  DisplayOverviewItineraries(mapViewModel = mapViewModel, profileViewModel = profileViewModel, sliderPositionState = sliderPositionState, sliderPositionTimeState = sliderPositionTimeState)
 }
 
 /** Displays global itineraries filtered on some predicates */
 @Composable
-fun DisplayOverviewItineraries(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel, sliderPositionState: MutableState<ClosedFloatingPointRange<Float>>) {
+fun DisplayOverviewItineraries(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel, sliderPositionState: MutableState<ClosedFloatingPointRange<Float>>, sliderPositionTimeState: MutableState<ClosedFloatingPointRange<Float>>) {
 
   /* the categories that can be selected by the user during filtering */
   val categoriesList =
@@ -52,7 +53,7 @@ fun DisplayOverviewItineraries(mapViewModel: MapViewModel, profileViewModel: Pro
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.fillMaxWidth().testTag("Overview screen")) {
-              SearchBar(onSearchChange = { searchQuery = it }, onPriceChange = { priceRange = it }, sliderPositionState = sliderPositionState)
+              SearchBar(onSearchChange = { searchQuery = it }, onPriceChange = { priceRange = it }, sliderPositionState = sliderPositionState, sliderPositionTimeState = sliderPositionTimeState)
               CategorySelector(
                   selectedIndex = selectedIndex,
                   categoriesList = categoriesList,
@@ -70,7 +71,9 @@ fun DisplayOverviewItineraries(mapViewModel: MapViewModel, profileViewModel: Pro
                 }.filter { itinerary ->
                     val price = itinerary.price.toFloat()
                     price in sliderPositionState.value.start..sliderPositionState.value.endInclusive
-                }
+                }.filter { itinerary ->
+                    val time = itinerary.time.toFloat()
+                    time in sliderPositionTimeState.value.start..sliderPositionTimeState.value.endInclusive }
         ItinerariesListScrollable(
             itineraries = filtered,
             paddingValues = innerPadding,

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/OverviewScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/OverviewScreen.kt
@@ -17,20 +17,28 @@ import androidx.compose.ui.platform.testTag
 import com.github.wanderwise_inc.app.R
 import com.github.wanderwise_inc.app.model.location.ItineraryTags
 import com.github.wanderwise_inc.app.ui.home.SearchBar
-
 import com.github.wanderwise_inc.app.viewmodel.MapViewModel
 import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
 
 @Composable
 fun OverviewScreen(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel) {
-    val sliderPositionState = remember { mutableStateOf(0f..100f)}
-    val sliderPositionTimeState = remember { mutableStateOf(0f..24f)}
-  DisplayOverviewItineraries(mapViewModel = mapViewModel, profileViewModel = profileViewModel, sliderPositionState = sliderPositionState, sliderPositionTimeState = sliderPositionTimeState)
+  val sliderPositionState = remember { mutableStateOf(0f..100f) }
+  val sliderPositionTimeState = remember { mutableStateOf(0f..24f) }
+  DisplayOverviewItineraries(
+      mapViewModel = mapViewModel,
+      profileViewModel = profileViewModel,
+      sliderPositionState = sliderPositionState,
+      sliderPositionTimeState = sliderPositionTimeState)
 }
 
 /** Displays global itineraries filtered on some predicates */
 @Composable
-fun DisplayOverviewItineraries(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel, sliderPositionState: MutableState<ClosedFloatingPointRange<Float>>, sliderPositionTimeState: MutableState<ClosedFloatingPointRange<Float>>) {
+fun DisplayOverviewItineraries(
+    mapViewModel: MapViewModel,
+    profileViewModel: ProfileViewModel,
+    sliderPositionState: MutableState<ClosedFloatingPointRange<Float>>,
+    sliderPositionTimeState: MutableState<ClosedFloatingPointRange<Float>>
+) {
 
   /* the categories that can be selected by the user during filtering */
   val categoriesList =
@@ -45,7 +53,6 @@ fun DisplayOverviewItineraries(mapViewModel: MapViewModel, profileViewModel: Pro
   var searchQuery by remember { mutableStateOf("") }
   var priceRange by remember { mutableStateOf(0f) }
 
-
   val itineraries by mapViewModel.getAllPublicItineraries().collectAsState(initial = listOf())
 
   Scaffold(
@@ -53,7 +60,11 @@ fun DisplayOverviewItineraries(mapViewModel: MapViewModel, profileViewModel: Pro
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.fillMaxWidth().testTag("Overview screen")) {
-              SearchBar(onSearchChange = { searchQuery = it }, onPriceChange = { priceRange = it }, sliderPositionState = sliderPositionState, sliderPositionTimeState = sliderPositionTimeState)
+              SearchBar(
+                  onSearchChange = { searchQuery = it },
+                  onPriceChange = { priceRange = it },
+                  sliderPositionState = sliderPositionState,
+                  sliderPositionTimeState = sliderPositionTimeState)
               CategorySelector(
                   selectedIndex = selectedIndex,
                   categoriesList = categoriesList,
@@ -68,12 +79,17 @@ fun DisplayOverviewItineraries(mapViewModel: MapViewModel, profileViewModel: Pro
                   searchQuery.isBlank() ||
                       itinerary.title.contains(searchQuery, ignoreCase = true) ||
                       itinerary.description?.contains(searchQuery, ignoreCase = true) ?: false
-                }.filter { itinerary ->
-                    val price = itinerary.price.toFloat()
-                    price in sliderPositionState.value.start..sliderPositionState.value.endInclusive
-                }.filter { itinerary ->
-                    val time = itinerary.time.toFloat()
-                    time in sliderPositionTimeState.value.start..sliderPositionTimeState.value.endInclusive }
+                }
+                .filter { itinerary ->
+                  val price = itinerary.price.toFloat()
+                  price in sliderPositionState.value.start..sliderPositionState.value.endInclusive
+                }
+                .filter { itinerary ->
+                  val time = itinerary.time.toFloat()
+                  time in
+                      sliderPositionTimeState.value.start..sliderPositionTimeState.value
+                              .endInclusive
+                }
         ItinerariesListScrollable(
             itineraries = filtered,
             paddingValues = innerPadding,

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/OverviewScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/OverviewScreen.kt
@@ -22,12 +22,12 @@ import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
 
 @Composable
 fun OverviewScreen(mapViewModel: MapViewModel, profileViewModel: ProfileViewModel) {
-  val sliderPositionState = remember { mutableStateOf(0f..100f) }
+  val sliderPositionPriceState = remember { mutableStateOf(0f..100f) }
   val sliderPositionTimeState = remember { mutableStateOf(0f..24f) }
   DisplayOverviewItineraries(
       mapViewModel = mapViewModel,
       profileViewModel = profileViewModel,
-      sliderPositionState = sliderPositionState,
+      sliderPositionPriceState = sliderPositionPriceState,
       sliderPositionTimeState = sliderPositionTimeState)
 }
 
@@ -36,7 +36,7 @@ fun OverviewScreen(mapViewModel: MapViewModel, profileViewModel: ProfileViewMode
 fun DisplayOverviewItineraries(
     mapViewModel: MapViewModel,
     profileViewModel: ProfileViewModel,
-    sliderPositionState: MutableState<ClosedFloatingPointRange<Float>>,
+    sliderPositionPriceState: MutableState<ClosedFloatingPointRange<Float>>,
     sliderPositionTimeState: MutableState<ClosedFloatingPointRange<Float>>
 ) {
 
@@ -63,7 +63,7 @@ fun DisplayOverviewItineraries(
               SearchBar(
                   onSearchChange = { searchQuery = it },
                   onPriceChange = { priceRange = it },
-                  sliderPositionState = sliderPositionState,
+                  sliderPositionPriceState = sliderPositionPriceState,
                   sliderPositionTimeState = sliderPositionTimeState)
               CategorySelector(
                   selectedIndex = selectedIndex,
@@ -82,7 +82,7 @@ fun DisplayOverviewItineraries(
                 }
                 .filter { itinerary ->
                   val price = itinerary.price.toFloat()
-                  price in sliderPositionState.value.start..sliderPositionState.value.endInclusive
+                  price in sliderPositionPriceState.value.start..sliderPositionPriceState.value.endInclusive
                 }
                 .filter { itinerary ->
                   val time = itinerary.time.toFloat()

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/MapViewModel.kt
@@ -1,7 +1,6 @@
 package com.github.wanderwise_inc.app.viewmodel
 
 import android.location.Location
-import androidx.annotation.FloatRange
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -127,7 +126,7 @@ class MapViewModel(
     return userLocationClient.getLocationUpdates(1000)
   }
 
- /* fun filterItinerariesByPrice(priceRange: FloatRange): List<Itinerary> {
+  /* fun filterItinerariesByPrice(priceRange: FloatRange): List<Itinerary> {
     return allItineraries.filter { it.price in priceRange }
   }*/
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/MapViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.wanderwise_inc.app.viewmodel
 
 import android.location.Location
+import androidx.annotation.FloatRange
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -125,4 +126,8 @@ class MapViewModel(
   fun getUserLocation(): Flow<Location> {
     return userLocationClient.getLocationUpdates(1000)
   }
+
+ /* fun filterItinerariesByPrice(priceRange: FloatRange): List<Itinerary> {
+    return allItineraries.filter { it.price in priceRange }
+  }*/
 }


### PR DESCRIPTION
- The user is now able to filter with a SliderRange the price and the time, the interval has been set at 0-100 and 0-24 respectively, the values of the Floats have been shortened for aesthetic reasons (.2f).
- it works on the OverviewScreen and on the LikedScreen.
- this features offers the possibility for a user to see itinerary banners that satisfy both conditions on the price and time.
- it is a slider ranger so you get the option to make it an interval rather than a fixed value