### PR TITLE
Small changed to `PreviewItineraryScreen`, `OverviewScreen` and `LikedScreen`

### DIFF
--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/LikedScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/LikedScreen.kt
@@ -69,7 +69,7 @@ fun DisplayLikedItineraries(
   val categoriesList =
       listOf(
           SearchCategory(ItineraryTags.ADVENTURE, R.drawable.adventure_icon, "Adventure"),
-          SearchCategory(ItineraryTags.LUXURY, R.drawable.adventure_icon, "Shopping"),
+          SearchCategory(ItineraryTags.LUXURY, R.drawable.shopping_icon, "Shopping"),
           SearchCategory(ItineraryTags.PHOTOGRAPHY, R.drawable.sight_seeing_icon, "Sight Seeing"),
           SearchCategory(ItineraryTags.FOODIE, R.drawable.drinks_icon, "Drinks"),
       )

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/OverviewScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/OverviewScreen.kt
@@ -57,7 +57,7 @@ fun DisplayOverviewItineraries(
   val categoriesList =
       listOf(
           SearchCategory(ItineraryTags.ADVENTURE, R.drawable.adventure_icon, "Adventure"),
-          SearchCategory(ItineraryTags.LUXURY, R.drawable.adventure_icon, "Shopping"),
+          SearchCategory(ItineraryTags.LUXURY, R.drawable.shopping_icon, "Shopping"),
           SearchCategory(ItineraryTags.PHOTOGRAPHY, R.drawable.sight_seeing_icon, "Sight Seeing"),
           SearchCategory(ItineraryTags.FOODIE, R.drawable.drinks_icon, "Drinks"),
       )

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
@@ -222,7 +222,7 @@ private fun PreviewItineraryBannerMaximized(
                           tint = MaterialTheme.colorScheme.secondary,
                           modifier = Modifier.size(width = 25.dp, height = 25.dp))
                       Text(
-                          text = "N/A hours",
+                          text = "${itinerary.time} hours",
                           color = MaterialTheme.colorScheme.secondary,
                           fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
                           fontSize = innerFontSize,
@@ -244,7 +244,7 @@ private fun PreviewItineraryBannerMaximized(
                           tint = MaterialTheme.colorScheme.secondary,
                           modifier = Modifier.size(width = 20.dp, height = 20.dp))
                       Text(
-                          text = "\$N/A - \$N/A",
+                          text = "${itinerary.price.toInt()} \$",
                           color = MaterialTheme.colorScheme.secondary,
                           fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
                           fontSize = innerFontSize,


### PR DESCRIPTION
- `PreviewItineraryScreen`: added time + duration to the banner as discussed in meeting today
- `OverviewScreen`/`LikedScreen`: changed the shopping logo which was incorrect previously.