### PR TITLE
Quick fix: signin crashing when device is offline

### DIFF
--- a/app/src/main/java/com/github/wanderwise_inc/app/DemoSetup.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/DemoSetup.kt
@@ -3,6 +3,7 @@ package com.github.wanderwise_inc.app
 import com.github.wanderwise_inc.app.model.location.Itinerary
 import com.github.wanderwise_inc.app.model.location.ItineraryTags
 import com.github.wanderwise_inc.app.model.location.PlacesReader
+import com.github.wanderwise_inc.app.model.profile.DEFAULT_OFFLINE_PROFILE
 import com.github.wanderwise_inc.app.model.profile.Profile
 import com.github.wanderwise_inc.app.viewmodel.ItineraryViewModel
 import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
@@ -61,6 +62,8 @@ fun addItineraries(
 ) {
   val defaultLocations = PlacesReader(null).readFromString()
 
+  profileViewModel.setActiveProfile(DEFAULT_OFFLINE_PROFILE)
+
   val itineraryAdventureAndLuxury =
       Itinerary(
           userUid = OTHER_USER_UID,
@@ -73,7 +76,7 @@ fun addItineraries(
 
   val itineraryAdventure =
       Itinerary(
-          userUid = OTHER_USER_UID,
+          userUid = profileViewModel.getUserUid(),
           locations = defaultLocations,
           title = "Hike",
           tags =
@@ -92,11 +95,13 @@ fun addItineraries(
           price = 25.0f,
       )
 
-  val currentUserUid = firebaseAuth.currentUser?.uid ?: DEFAULT_USER_UID
+  /** default profile for demo-ing */
+  val dummyProfile =
+      Profile(uid = DEFAULT_USER_UID, userUid = "-1", bio = "uwu", displayName = "John Doe")
 
   val privateItinerary =
       Itinerary(
-          userUid = currentUserUid,
+          userUid = profileViewModel.getUserUid(),
           locations = defaultLocations,
           title = "My private itinerary",
           tags = listOf(ItineraryTags.ADVENTURE),
@@ -107,7 +112,7 @@ fun addItineraries(
   val publicItinerary =
       Itinerary(
           uid = PREVIEW_ITINERARY_DEMO_UID,
-          userUid = FirebaseAuth.getInstance().currentUser?.uid ?: "NULL_UID",
+          userUid = profileViewModel.getUserUid(),
           locations = defaultLocations,
           title = "San Francisco Bike Itinerary",
           tags = listOf(ItineraryTags.CULTURAL, ItineraryTags.NATURE, ItineraryTags.BUDGET),
@@ -122,5 +127,5 @@ fun addItineraries(
   for (i in 0..1023) itineraryViewModel.incrementItineraryLikes(publicItinerary)
 
   // other profile likes their own itinerary
-  profileViewModel.addLikedItinerary(OTHER_USER_UID, itineraryAdventure.uid)
+  profileViewModel.addLikedItinerary(itineraryAdventure.uid)
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/MainActivity.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/MainActivity.kt
@@ -71,15 +71,10 @@ class MainActivity : ComponentActivity() {
   private val signInLauncher by lazy {
     registerForActivityResult(FirebaseAuthUIActivityResultContract()) { res ->
       /* on failure, don't throw an exception. Pass the null value down for proper handling */
-      val currUser =
-        if (res.resultCode != RESULT_OK)
-          firebaseAuth.currentUser
-        else
-          null
+      val currUser = if (res.resultCode != RESULT_OK) firebaseAuth.currentUser else null
 
-      lifecycleScope.launch {
-        signInRepository.signIn(navController, profileViewModel, currUser)
-      }
+      Log.d("MainActivity", "Firebase sign-in result: $currUser")
+      lifecycleScope.launch { signInRepository.signIn(navController, profileViewModel, currUser) }
     }
   }
 

--- a/app/src/main/java/com/github/wanderwise_inc/app/MainActivity.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/MainActivity.kt
@@ -70,10 +70,15 @@ class MainActivity : ComponentActivity() {
 
   private val signInLauncher by lazy {
     registerForActivityResult(FirebaseAuthUIActivityResultContract()) { res ->
-      if (res.resultCode != RESULT_OK) throw Exception("User unsuccessful sign in")
+      /* on failure, don't throw an exception. Pass the null value down for proper handling */
+      val currUser =
+        if (res.resultCode != RESULT_OK)
+          firebaseAuth.currentUser
+        else
+          null
 
       lifecycleScope.launch {
-        signInRepository.signIn(navController, profileViewModel, firebaseAuth.currentUser)
+        signInRepository.signIn(navController, profileViewModel, currUser)
       }
     }
   }

--- a/app/src/main/java/com/github/wanderwise_inc/app/MainActivity.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/MainActivity.kt
@@ -71,7 +71,7 @@ class MainActivity : ComponentActivity() {
   private val signInLauncher by lazy {
     registerForActivityResult(FirebaseAuthUIActivityResultContract()) { res ->
       /* on failure, don't throw an exception. Pass the null value down for proper handling */
-      val currUser = if (res.resultCode != RESULT_OK) firebaseAuth.currentUser else null
+      val currUser = if (res.resultCode == RESULT_OK) firebaseAuth.currentUser else null
 
       Log.d("MainActivity", "Firebase sign-in result: $currUser")
       lifecycleScope.launch { signInRepository.signIn(navController, profileViewModel, currUser) }

--- a/app/src/main/java/com/github/wanderwise_inc/app/data/ProfileRepositoryTestImpl.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/data/ProfileRepositoryTestImpl.kt
@@ -1,5 +1,6 @@
 package com.github.wanderwise_inc.app.data
 
+import android.util.Log
 import com.github.wanderwise_inc.app.model.profile.Profile
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -35,15 +36,27 @@ class ProfileRepositoryTestImpl : ProfileRepository {
   }
 
   override fun addItineraryToLiked(userUid: String, itineraryUid: String) {
-    profiles.first { it.userUid == userUid }.likedItinerariesUid.add(itineraryUid)
+    try {
+      profiles.first { it.userUid == userUid }.likedItinerariesUid.add(itineraryUid)
+    } catch (e: Exception) {
+      Log.d("ProfileRepository", "Failed to add to liked: $e")
+    }
   }
 
   override fun removeItineraryFromLiked(userUid: String, itineraryUid: String) {
-    profiles.first { it.userUid == userUid }.likedItinerariesUid.remove(itineraryUid)
+    try {
+      profiles.first { it.userUid == userUid }.likedItinerariesUid.remove(itineraryUid)
+    } catch (e: Exception) {
+      Log.d("ProfileRepository", "Failed to remove from liked: $e")
+    }
   }
 
   override suspend fun checkIfItineraryIsLiked(userUid: String, itineraryUid: String): Boolean {
-    return profiles.first { it.userUid == userUid }.likedItinerariesUid.contains(itineraryUid)
+    return try {
+      profiles.first { it.userUid == userUid }.likedItinerariesUid.contains(itineraryUid)
+    } catch (e: Exception) {
+      false
+    }
   }
 
   override fun getLikedItineraries(userUid: String): Flow<List<String>> {

--- a/app/src/main/java/com/github/wanderwise_inc/app/data/SignInRepositoryImpl.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/data/SignInRepositoryImpl.kt
@@ -15,7 +15,7 @@ class SignInRepositoryImpl : SignInRepository {
       user: FirebaseUser?,
   ) {
     if (user == null) {
-      profileViewModel.setProfile(DEFAULT_OFFLINE_PROFILE)
+      profileViewModel.setActiveProfile(DEFAULT_OFFLINE_PROFILE)
     } else {
       // Get the user from database
       val currentProfile = profileViewModel.getProfile(user.uid).first()
@@ -39,8 +39,9 @@ class SignInRepositoryImpl : SignInRepository {
 
         // Set the user to the database
         profileViewModel.setProfile(newProfile)
-        navController.navigate(Graph.HOME)
+        profileViewModel.setActiveProfile(newProfile)
       }
     }
+    navController.navigate(Graph.HOME)
   }
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/data/SignInRepositoryImpl.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/data/SignInRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.github.wanderwise_inc.app.data
 
 import androidx.navigation.NavController
+import com.github.wanderwise_inc.app.model.profile.DEFAULT_OFFLINE_PROFILE
 import com.github.wanderwise_inc.app.model.profile.Profile
 import com.github.wanderwise_inc.app.ui.navigation.graph.Graph
 import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
@@ -14,7 +15,7 @@ class SignInRepositoryImpl : SignInRepository {
       user: FirebaseUser?,
   ) {
     if (user == null) {
-      throw Exception("User is Null")
+      profileViewModel.setProfile(DEFAULT_OFFLINE_PROFILE)
     } else {
       // Get the user from database
       val currentProfile = profileViewModel.getProfile(user.uid).first()

--- a/app/src/main/java/com/github/wanderwise_inc/app/model/profile/Profile.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/model/profile/Profile.kt
@@ -38,3 +38,11 @@ data class Profile(
       userUid: String,
   ) : this(displayName = "", userUid = userUid, bio = "")
 }
+
+/** set in `ProfileViewModel` on sign-in failure and when no data is cached */
+val DEFAULT_OFFLINE_PROFILE =
+    Profile(
+        uid = "-1",
+        displayName = "Anonymous Wanderer",
+        userUid = "-1",
+        bio = "Wandering without connection")

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/ItineraryList.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/ItineraryList.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
-import com.github.wanderwise_inc.app.DEFAULT_USER_UID
 import com.github.wanderwise_inc.app.model.location.Itinerary
 import com.github.wanderwise_inc.app.ui.TestTags
 import com.github.wanderwise_inc.app.ui.itinerary.ItineraryBanner
@@ -74,19 +73,19 @@ fun ItinerariesListScrollable(
         modifier = Modifier.padding(paddingValues).testTag(TestTags.ITINERARY_LIST_SCROLLABLE),
         verticalArrangement = spacedBy(15.dp)) {
           this.items(itineraries) { itinerary ->
-            val uid = firebaseAuth.currentUser?.uid ?: DEFAULT_USER_UID
+            val uid = profileViewModel.getUserUid()
             val isLikedInitially: Boolean
             runBlocking {
-              isLikedInitially = profileViewModel.checkIfItineraryIsLiked(uid, itinerary.uid)
+              isLikedInitially = profileViewModel.checkIfItineraryIsLiked(itinerary.uid)
             }
 
             val onLikeButtonClick = { it: Itinerary, isLiked: Boolean ->
               if (isLiked) {
                 itineraryViewModel.decrementItineraryLikes(it)
-                profileViewModel.removeLikedItinerary(uid, it.uid)
+                profileViewModel.removeLikedItinerary(it.uid)
               } else {
                 itineraryViewModel.incrementItineraryLikes(it)
-                profileViewModel.addLikedItinerary(uid, it.uid)
+                profileViewModel.addLikedItinerary(it.uid)
               }
             }
             val navigationActions = NavigationActions(navController)

--- a/app/src/test/java/com/github/wanderwise_inc/app/data/SignInRepositoryTest.kt
+++ b/app/src/test/java/com/github/wanderwise_inc/app/data/SignInRepositoryTest.kt
@@ -8,6 +8,7 @@ import com.google.firebase.auth.FirebaseUser
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -35,9 +36,13 @@ class SignInRepositoryTest {
     signInRepositoryImpl = SignInRepositoryImpl()
   }
 
-  @Test(expected = Exception::class)
-  fun `if user is Null then nothing should happen`() = runTest {
-    signInRepositoryImpl.signIn(navController, profileViewModel, null)
+  @Test
+  fun `if user is null, no exception should be thrown`() = runTest {
+    try {
+      signInRepositoryImpl.signIn(navController, profileViewModel, null)
+    } catch (e: Exception) {
+      fail("signIn should not throw. Exception was $e")
+    }
   }
 
   @Test


### PR DESCRIPTION
related to #218 

- Removed unhandled `throws` relating to sign-in logic from `MainActivity` and `SigninRepositoryImpl`
- We now set a default instance `DEFAULT_OFFLINE_PROFILE` on failure. 

## TODO

Once caching is fully implemented and working, we should be fetching cached profile instead of setting a default offline instance. Check https://github.com/WanderWise-Inc/app/pull/220 for progress