### PR TITLE
Fixed like button bug

### DIFF
--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/ItineraryList.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/ItineraryList.kt
@@ -73,7 +73,7 @@ fun ItinerariesListScrollable(
     LazyColumn(
         modifier = Modifier.padding(paddingValues).testTag(TestTags.ITINERARY_LIST_SCROLLABLE),
         verticalArrangement = spacedBy(15.dp)) {
-          this.items(itineraries, { (iti) -> iti}) { itinerary ->
+          this.items(itineraries, { (iti) -> iti }) { itinerary ->
             val uid = firebaseAuth.currentUser?.uid ?: DEFAULT_USER_UID
             val isLikedInitially: Boolean
             runBlocking {

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/ItineraryList.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/ItineraryList.kt
@@ -73,7 +73,7 @@ fun ItinerariesListScrollable(
     LazyColumn(
         modifier = Modifier.padding(paddingValues).testTag(TestTags.ITINERARY_LIST_SCROLLABLE),
         verticalArrangement = spacedBy(15.dp)) {
-          this.items(itineraries) { itinerary ->
+          this.items(itineraries, { (iti) -> iti}) { itinerary ->
             val uid = firebaseAuth.currentUser?.uid ?: DEFAULT_USER_UID
             val isLikedInitially: Boolean
             runBlocking {


### PR DESCRIPTION
Found an issue where the following bug occurs:
1. Go to overview screen
2. Like the first itinerary (Hike)
3. Change category to Shopping (was Adventure)
4. The itinerary displayed (Shopping and Adventure) is liked when it shouldn't be

This change fixes the aforementioned issue.