### PR TITLE
Updated `AppModule`, its test file, and how it's initialized in MainActivity

### DIFF
--- a/app/src/main/java/com/github/wanderwise_inc/app/MainActivity.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/MainActivity.kt
@@ -37,6 +37,7 @@ import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
 import com.github.wanderwise_inc.app.viewmodel.UserLocationClient
 import com.google.android.gms.location.LocationServices
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.launch
 
@@ -127,7 +128,10 @@ class MainActivity : ComponentActivity() {
         signInIntent,
         locationClient,
         savedItinerariesDataStore,
-        applicationContext)
+        applicationContext,
+        FirebaseAuth.getInstance(),
+        FirebaseFirestore.getInstance(),
+        FirebaseStorage.getInstance())
 
     firebaseAuth = AppModule.firebaseAuth
     firebaseStorage = AppModule.firebaseStorage

--- a/app/src/main/java/com/github/wanderwise_inc/app/di/AppModule.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/di/AppModule.kt
@@ -1,8 +1,5 @@
 package com.github.wanderwise_inc.app.di
 
-// import android.content.Context
-// import androidx.datastore.core.DataStore
-// import com.github.wanderwise_inc.app.proto.location.SavedItineraries
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
@@ -35,6 +32,9 @@ object AppModule {
   private lateinit var locationClient: LocationClient
   private lateinit var savedItinerariesDataStore: DataStore<SavedItineraries>
   private lateinit var context: Context
+  lateinit var firebaseAuth: FirebaseAuth
+  lateinit var db: FirebaseFirestore
+  lateinit var firebaseStorage: FirebaseStorage
 
   init {
     Log.d("ModuleProvider", "Using AppModule")
@@ -47,6 +47,9 @@ object AppModule {
       locationClient: LocationClient,
       savedItinerariesDataStore: DataStore<SavedItineraries>,
       context: Context,
+      firebaseAuth: FirebaseAuth,
+      firebaseFirestore: FirebaseFirestore,
+      firebaseStorage: FirebaseStorage
   ) {
     this.imageLauncher = imageLauncher
     this.signInLauncher = signInLauncher
@@ -54,12 +57,10 @@ object AppModule {
     this.locationClient = locationClient
     this.savedItinerariesDataStore = savedItinerariesDataStore
     this.context = context
+    this.firebaseAuth = firebaseAuth
+    this.db = firebaseFirestore
+    this.firebaseStorage = firebaseStorage
   }
-
-  val firebaseAuth by lazy { FirebaseAuth.getInstance() }
-
-  val firebaseStorage by lazy { FirebaseStorage.getInstance() }
-  val db by lazy { FirebaseFirestore.getInstance() }
 
   val imageRepository by lazy {
     ImageRepositoryImpl(imageLauncher, firebaseStorage.reference, null)

--- a/app/src/test/java/com/github/wanderwise_inc/app/di/AppModuleTest.kt
+++ b/app/src/test/java/com/github/wanderwise_inc/app/di/AppModuleTest.kt
@@ -1,37 +1,48 @@
 package com.github.wanderwise_inc.app.di
 
-/*
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.ActivityResultLauncher
 import androidx.datastore.core.DataStore
 import com.github.wanderwise_inc.app.proto.location.SavedItineraries
 import com.github.wanderwise_inc.app.viewmodel.LocationClient
-import com.google.firebase.FirebaseApp
-import io.mockk.impl.annotations.MockK
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.storage.FirebaseStorage
+import com.google.firebase.storage.StorageReference
+import io.mockk.every
 import io.mockk.mockk
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class AppModuleTest {
 
   @Before
   fun setUp() {
-    FirebaseApp.initializeApp(RuntimeEnvironment.getApplication())
+    val mockCollectionRef = mockk<CollectionReference>()
+    val mockStorageref = mockk<StorageReference>()
+    val mockDb = mockk<FirebaseFirestore>()
+    val mockStorage = mockk<FirebaseStorage>()
+    every { mockDb.collection(any()) } returns mockCollectionRef
+    every { mockStorage.getReference() } returns mockStorageref
+
+    // FirebaseApp.initializeApp(RuntimeEnvironment.getApplication())
     AppModule.initialize(
         mockk<ActivityResultLauncher<Intent>>(),
         mockk<ActivityResultLauncher<Intent>>(),
         mockk<Intent>(),
         mockk<LocationClient>(),
         mockk<DataStore<SavedItineraries>>(),
-        mockk<Context>())
+        mockk<Context>(),
+        mockk<FirebaseAuth>(),
+        mockDb,
+        mockStorage)
   }
 
   @Test
@@ -142,4 +153,3 @@ class AppModuleTest {
     assertEquals(result1, result2)
   }
 }
-*/


### PR DESCRIPTION
## Fixes test incompatibility relating to `FirebaseApp.initializeApp()`
- `FirebaseAuth`, `FirebaseFirestore` and `FirebaseStorage` passed as parameters into `AppModule` directly, delegating their initialization to the initializer of `AppModule` instead of `lazy` initializing them inside the object implicitly
- tests now mock the relevant fields
- `MainActivity` initializes the related fields after calling`FirebaseApp.initializeApp()` (required, this was making tests fail previously when called in roboelectric runtime)