### PR TITLE
Bypass sign-in in offline mode

### DIFF
--- a/app/src/main/java/com/github/wanderwise_inc/app/data/ProfileRepositoryImpl.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/data/ProfileRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package com.github.wanderwise_inc.app.data
 
+import android.content.Context
 import android.util.Log
+import com.github.wanderwise_inc.app.isNetworkAvailable
 import com.github.wanderwise_inc.app.model.profile.Profile
 import com.github.wanderwise_inc.app.model.profile.ProfileLabels
 import com.google.firebase.firestore.DocumentSnapshot
@@ -15,7 +17,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 
 const val PROFILE_DB_PATH = "profiles"
 
-class ProfileRepositoryImpl(db: FirebaseFirestore) : ProfileRepository {
+class ProfileRepositoryImpl(db: FirebaseFirestore, val context: Context) : ProfileRepository {
   private val usersCollection = db.collection(PROFILE_DB_PATH)
 
   override fun getProfile(userUid: String): Flow<Profile?> {
@@ -123,6 +125,16 @@ class ProfileRepositoryImpl(db: FirebaseFirestore) : ProfileRepository {
   }
 
   override suspend fun checkIfItineraryIsLiked(userUid: String, itineraryUid: String): Boolean {
+    return when (context.isNetworkAvailable()) {
+      true -> checkIfItineraryIsLikedOnline(userUid, itineraryUid)
+      false -> false // if an itinerary is available offline, it was liked by user
+    }
+  }
+
+  private suspend fun checkIfItineraryIsLikedOnline(
+      userUid: String,
+      itineraryUid: String
+  ): Boolean {
     val isLiked = suspendCancellableCoroutine { continuation ->
       usersCollection
           .document(userUid)

--- a/app/src/main/java/com/github/wanderwise_inc/app/data/ProfileRepositoryImpl.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/data/ProfileRepositoryImpl.kt
@@ -127,7 +127,7 @@ class ProfileRepositoryImpl(db: FirebaseFirestore, val context: Context) : Profi
   override suspend fun checkIfItineraryIsLiked(userUid: String, itineraryUid: String): Boolean {
     return when (context.isNetworkAvailable()) {
       true -> checkIfItineraryIsLikedOnline(userUid, itineraryUid)
-      false -> false // if an itinerary is available offline, it was liked by user
+      false -> false // sensible default. Applies only to locally saved itineraries
     }
   }
 

--- a/app/src/main/java/com/github/wanderwise_inc/app/di/AppModule.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/di/AppModule.kt
@@ -21,6 +21,7 @@ import com.github.wanderwise_inc.app.data.LocationsRepositoryImpl
 import com.github.wanderwise_inc.app.data.ProfileRepositoryImpl
 import com.github.wanderwise_inc.app.data.SignInLauncher
 import com.github.wanderwise_inc.app.disk.SavedItinerariesSerializer
+import com.github.wanderwise_inc.app.isNetworkAvailable
 import com.github.wanderwise_inc.app.network.DirectionsApiServiceFactory
 import com.github.wanderwise_inc.app.network.LocationsApiServiceFactory
 import com.github.wanderwise_inc.app.proto.location.SavedItineraries
@@ -82,7 +83,7 @@ class AppModule(
     LocationsRepositoryImpl(LocationsApiServiceFactory.createLocationsApiService())
   }
 
-  val profileRepository by lazy { ProfileRepositoryImpl(firestore) }
+  val profileRepository by lazy { ProfileRepositoryImpl(firestore, activity.applicationContext) }
 
   val bottomNavigationViewModel: BottomNavigationViewModel by lazy { BottomNavigationViewModel() }
 
@@ -102,7 +103,9 @@ class AppModule(
         LocationServices.getFusedLocationProviderClient(activity.applicationContext))
   }
 
-  val loginViewModel: LoginViewModel by lazy { LoginViewModel(signInLauncher) }
+  val loginViewModel: LoginViewModel by lazy {
+    LoginViewModel(signInLauncher, activity.applicationContext.isNetworkAvailable())
+  }
 
   private val signInLauncher: SignInLauncher by lazy {
     GoogleSignInLauncher(activityResultLauncher)

--- a/app/src/main/java/com/github/wanderwise_inc/app/model/profile/Profile.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/model/profile/Profile.kt
@@ -33,5 +33,4 @@ data class Profile(
 
 /** set in `ProfileViewModel` on sign-in failure and when no data is cached */
 val DEFAULT_OFFLINE_PROFILE =
-    Profile(
-        displayName = "Anonymous Wanderer", userUid = "-1", bio = "Wandering without connection")
+    Profile(displayName = "Offline Wanderer", userUid = "-1", bio = "Wandering without connection")

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/ItineraryList.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/ItineraryList.kt
@@ -34,10 +34,12 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import com.github.wanderwise_inc.app.data.ImageRepository
 import com.github.wanderwise_inc.app.model.location.Itinerary
+import com.github.wanderwise_inc.app.model.profile.DEFAULT_OFFLINE_PROFILE
 import com.github.wanderwise_inc.app.ui.TestTags
 import com.github.wanderwise_inc.app.ui.itinerary.ItineraryBanner
 import com.github.wanderwise_inc.app.ui.navigation.Destination
 import com.github.wanderwise_inc.app.ui.navigation.NavigationActions
+import com.github.wanderwise_inc.app.ui.popup.HintPopup
 import com.github.wanderwise_inc.app.viewmodel.ItineraryViewModel
 import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
 
@@ -93,12 +95,15 @@ fun ItinerariesListScrollable(
             }
 
             val onLikeButtonClick = { it: Itinerary, isLiked: Boolean ->
-              if (isLiked) {
-                itineraryViewModel.decrementItineraryLikes(it)
-                profileViewModel.removeLikedItinerary(uid, it.uid)
-              } else {
-                itineraryViewModel.incrementItineraryLikes(it)
-                profileViewModel.addLikedItinerary(uid, it.uid)
+              // liking should have no effect for the offline profile!
+              if (profileViewModel.getUserUid() != DEFAULT_OFFLINE_PROFILE.userUid) {
+                if (isLiked) {
+                  itineraryViewModel.decrementItineraryLikes(it)
+                  profileViewModel.removeLikedItinerary(uid, it.uid)
+                } else {
+                  itineraryViewModel.incrementItineraryLikes(it)
+                  profileViewModel.addLikedItinerary(uid, it.uid)
+                }
               }
             }
             val navigationActions = NavigationActions(navController)
@@ -115,6 +120,12 @@ fun ItinerariesListScrollable(
                 imageRepository = imageRepository)
           }
         }
+  }
+  var offlineHintVisible by remember {
+    mutableStateOf(profileViewModel.getUserUid() == DEFAULT_OFFLINE_PROFILE.userUid)
+  }
+  if (offlineHintVisible) {
+    HintPopup(message = "You are currently offline!") { offlineHintVisible = false }
   }
 }
 

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/navigation/graph/AuthNavGraph.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/navigation/graph/AuthNavGraph.kt
@@ -7,13 +7,20 @@ import androidx.navigation.navigation
 import com.github.wanderwise_inc.app.ui.navigation.TopLevelRoute
 import com.github.wanderwise_inc.app.ui.signin.LoginScreen
 import com.github.wanderwise_inc.app.viewmodel.LoginViewModel
+import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
 
-fun NavGraphBuilder.authNavGraph(loginViewModel: LoginViewModel, navController: NavController) {
+fun NavGraphBuilder.authNavGraph(
+    loginViewModel: LoginViewModel,
+    profileViewModel: ProfileViewModel,
+    navController: NavController
+) {
   navigation(
       route = Graph.AUTHENTICATION,
       startDestination = AuthScreen.SignIn.route,
   ) {
-    composable(route = AuthScreen.SignIn.route) { LoginScreen(loginViewModel, navController) }
+    composable(route = AuthScreen.SignIn.route) {
+      LoginScreen(loginViewModel, profileViewModel, navController)
+    }
   }
 }
 

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/navigation/graph/RootNavGraph.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/navigation/graph/RootNavGraph.kt
@@ -24,7 +24,7 @@ fun RootNavigationGraph(
 ) {
   NavHost(
       navController = navController, route = Graph.ROOT, startDestination = Graph.AUTHENTICATION) {
-        authNavGraph(loginViewModel, navController)
+        authNavGraph(loginViewModel, profileViewModel, navController)
         composable(route = Graph.HOME) {
           HomeScreen(
               imageRepository = imageRepository,

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/signin/LoginScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/signin/LoginScreen.kt
@@ -23,18 +23,27 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.github.wanderwise_inc.app.R
+import com.github.wanderwise_inc.app.model.profile.DEFAULT_OFFLINE_PROFILE
 import com.github.wanderwise_inc.app.ui.TestTags
 import com.github.wanderwise_inc.app.ui.navigation.graph.Graph
 import com.github.wanderwise_inc.app.viewmodel.LoginViewModel
+import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
 import com.github.wanderwise_inc.app.viewmodel.SignInState
 import kotlinx.coroutines.delay
 
 @Composable
-fun LoginScreen(loginViewModel: LoginViewModel, navController: NavController) {
+fun LoginScreen(
+    loginViewModel: LoginViewModel,
+    profileViewModel: ProfileViewModel,
+    navController: NavController
+) {
   val signInState by loginViewModel.signInState.observeAsState()
 
   LaunchedEffect(signInState) {
     if (signInState == SignInState.SUCCESS) {
+      navController.navigate(Graph.HOME)
+    } else if (signInState == SignInState.OFFLINE) {
+      profileViewModel.setActiveProfile(DEFAULT_OFFLINE_PROFILE)
       navController.navigate(Graph.HOME)
     }
   }
@@ -45,8 +54,8 @@ fun LoginScreen(loginViewModel: LoginViewModel, navController: NavController) {
           R.drawable.venice,
           R.drawable.waterfall,
           R.drawable.cathedral)
-  var currentImageIndex by remember { mutableStateOf(0) }
-  val infiniteTransition = rememberInfiniteTransition()
+  var currentImageIndex by remember { mutableIntStateOf(0) }
+  val infiniteTransition = rememberInfiniteTransition(label = "Sign-in Infinite Transition")
   val alpha by
       infiniteTransition.animateFloat(
           initialValue = 0.6f,
@@ -123,6 +132,8 @@ fun LoginScreen(loginViewModel: LoginViewModel, navController: NavController) {
 
 @Composable
 fun SignInButton(loginViewModel: LoginViewModel) {
+  var signInState = loginViewModel.signInState.observeAsState()
+
   Button(
       onClick = { loginViewModel.signIn() },
       shape = RoundedCornerShape(16.dp),

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/LoginViewModel.kt
@@ -1,5 +1,6 @@
 package com.github.wanderwise_inc.app.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -8,13 +9,20 @@ import com.github.wanderwise_inc.app.model.profile.DEFAULT_OFFLINE_PROFILE
 import com.google.firebase.auth.FirebaseUser
 import kotlinx.coroutines.flow.first
 
-class LoginViewModel(private val signInLauncher: SignInLauncher) : ViewModel() {
+class LoginViewModel(
+    private val signInLauncher: SignInLauncher,
+    private val isNetworkAvailable: Boolean,
+) : ViewModel() {
   private val _signInState = MutableLiveData(SignInState.NONE)
   val signInState: LiveData<SignInState>
     get() = _signInState
 
   fun signIn() {
-    signInLauncher.signIn()
+    if (isNetworkAvailable) signInLauncher.signIn()
+    else {
+      Log.d("LoginViewModel", "Network unavailable")
+      _signInState.value = SignInState.OFFLINE
+    }
   }
 
   suspend fun handleSignInResult(
@@ -50,5 +58,6 @@ class LoginViewModel(private val signInLauncher: SignInLauncher) : ViewModel() {
 enum class SignInState {
   NONE,
   SUCCESS,
-  FAILURE
+  FAILURE,
+  OFFLINE,
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/ProfileViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import com.github.wanderwise_inc.app.data.ImageRepository
 import com.github.wanderwise_inc.app.data.ProfileRepository
 import com.github.wanderwise_inc.app.model.location.Itinerary
+import com.github.wanderwise_inc.app.model.profile.DEFAULT_OFFLINE_PROFILE
 import com.github.wanderwise_inc.app.model.profile.Profile
 import com.google.firebase.auth.FirebaseUser
 import kotlinx.coroutines.flow.Flow
@@ -49,16 +50,17 @@ class ProfileViewModel(
   }
 
   fun addLikedItinerary(userUid: String, itineraryUid: String) {
-    Log.d("ProfileViewModel", "adding liked itinerary")
+    if (userUid == DEFAULT_OFFLINE_PROFILE.userUid) return
     profileRepository.addItineraryToLiked(userUid, itineraryUid)
   }
 
   fun removeLikedItinerary(userUid: String, itineraryUid: String) {
+    if (userUid == DEFAULT_OFFLINE_PROFILE.userUid) return
     profileRepository.removeItineraryFromLiked(userUid, itineraryUid)
   }
 
   suspend fun checkIfItineraryIsLiked(userUid: String, itineraryUid: String): Boolean {
-    Log.d("ProfileViewModel", "checking if itinerary $itineraryUid is liked...")
+    if (userUid == DEFAULT_OFFLINE_PROFILE.userUid) return false
     return profileRepository.checkIfItineraryIsLiked(userUid, itineraryUid)
   }
 

--- a/app/src/test/java/com/github/wanderwise_inc/app/data/ProfileRepositoryTest.kt
+++ b/app/src/test/java/com/github/wanderwise_inc/app/data/ProfileRepositoryTest.kt
@@ -1,5 +1,9 @@
 package com.github.wanderwise_inc.app.data
 
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
 import com.github.wanderwise_inc.app.model.profile.Profile
 import com.google.android.gms.tasks.OnFailureListener
 import com.google.android.gms.tasks.OnSuccessListener
@@ -19,10 +23,12 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.Mockito.any
 import org.mockito.Mockito.anyString
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnit
 import org.mockito.junit.MockitoRule
@@ -41,6 +47,10 @@ class ProfileRepositoryTest {
   @Mock private lateinit var docSnap: DocumentSnapshot
   @Mock private lateinit var taskQuerySnap: Task<QuerySnapshot>
   @Mock private lateinit var querySnap: QuerySnapshot
+  @Mock private lateinit var context: Context
+  @Mock private lateinit var connectivityManager: ConnectivityManager
+  @Mock private lateinit var networkInfo: Network
+  @Mock private lateinit var networkCapabilities: NetworkCapabilities
 
   private lateinit var profileRepositoryTestImpl: ProfileRepository
   private lateinit var profileRepositoryImpl: ProfileRepository
@@ -50,10 +60,23 @@ class ProfileRepositoryTest {
   private lateinit var profiles: MutableList<Profile>
 
   @Before
-  fun setup() {
-    profileRepositoryTestImpl = ProfileRepositoryTestImpl()
+  fun `setup mocks`() {
+    context = mock()
+    connectivityManager = mock()
+    networkInfo = mock()
+    networkCapabilities = mock()
+
     `when`(db.collection(anyString())).thenReturn(userCollection)
-    profileRepositoryImpl = ProfileRepositoryImpl(db)
+    `when`(context.getSystemService(anyString())).thenReturn(connectivityManager)
+    `when`(connectivityManager.activeNetwork).thenReturn(networkInfo)
+    `when`(connectivityManager.getNetworkCapabilities(networkInfo)).thenReturn(networkCapabilities)
+    `when`(networkCapabilities.hasCapability(anyInt())).thenReturn(true)
+  }
+
+  @Before
+  fun `setup repositories and data`() {
+    profileRepositoryTestImpl = ProfileRepositoryTestImpl()
+    profileRepositoryImpl = ProfileRepositoryImpl(db, context)
     profile0 = Profile("0", "Profile0", "bio of Profile0")
     profile1 = Profile("1", "Profile1", "bio of Profile1")
     profile2 = Profile("2", "Profile2", "bio of Profile2")

--- a/app/src/test/java/com/github/wanderwise_inc/app/ui/signin/LoginScreenTest.kt
+++ b/app/src/test/java/com/github/wanderwise_inc/app/ui/signin/LoginScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.navigation.NavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.wanderwise_inc.app.ui.TestTags
 import com.github.wanderwise_inc.app.viewmodel.LoginViewModel
+import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
 import com.github.wanderwise_inc.app.viewmodel.SignInState
 import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
@@ -28,7 +29,7 @@ class LoginScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
 
   @MockK private lateinit var loginViewModel: LoginViewModel
-
+  @MockK private lateinit var profileViewModel: ProfileViewModel
   @MockK private lateinit var navController: NavController
 
   private val _signInState = MutableLiveData<SignInState>()
@@ -43,7 +44,7 @@ class LoginScreenTest {
 
     every { loginViewModel.signInState } returns signInState
 
-    composeTestRule.setContent { LoginScreen(loginViewModel, navController) }
+    composeTestRule.setContent { LoginScreen(loginViewModel, profileViewModel, navController) }
     composeTestRule.waitForIdle()
   }
 


### PR DESCRIPTION
# Changes

- When app boots offline, it will sign in using `DEFAULT_OFFLINE_PROFILE` value. Liking itineraries has no effect in offline mode. It is important that the app boots in offline mode - if the app launches and then is put into airplane mode, sign-in will still try to connect to firebase auth. I don't have a good solution for this as of right now.
- `LoginViewModel` now takes network status (boolean) to decide whether or not to attempt connection through firebase auth
- `ProfileRepositoryImpl` now takes context; this allows us to check network status on the fly and decide whether or not to try and fetch data from firestore
- Updated tests for compatibility with new context parameter.