### PR TITLE
Updated Itinerary banners.

### DIFF
--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/creation/steps/CreationStepChooseDescription.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/creation/steps/CreationStepChooseDescription.kt
@@ -46,7 +46,7 @@ fun CreationStepChooseDescriptionScreen(createItineraryViewModel: CreateItinerar
               modifier = Modifier.fillMaxSize().testTag(TestTags.CREATION_SCREEN_TITLE),
               value = title,
               onValueChange = {
-                  //cant add '\n' to titles
+                // cant add '\n' to titles
                 title = it.filter { c -> c != '\n' }
                 validTitle =
                     if (createItineraryViewModel.validTitle(title)) {

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/creation/steps/CreationStepChooseDescription.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/creation/steps/CreationStepChooseDescription.kt
@@ -39,24 +39,25 @@ fun CreationStepChooseDescriptionScreen(createItineraryViewModel: CreateItinerar
           Modifier.padding(top = 10.dp)
               .background(color = MaterialTheme.colorScheme.background)
               .testTag(TestTags.CREATION_SCREEN_DESCRIPTION_TITLE),
-      contentPadding = PaddingValues(24.dp),
-      verticalArrangement = Arrangement.Absolute.spacedBy(52.dp)) {
+      contentPadding = PaddingValues(10.dp),
+      verticalArrangement = Arrangement.Absolute.spacedBy(24.dp)) {
         item {
           OutlinedTextField(
               modifier = Modifier.fillMaxSize().testTag(TestTags.CREATION_SCREEN_TITLE),
               value = title,
               onValueChange = {
-                title = it
+                  //cant add '\n' to titles
+                title = it.filter { c -> c != '\n' }
                 validTitle =
-                    if (createItineraryViewModel.validTitle(it)) {
-                      createItineraryViewModel.getNewItinerary()?.title(it)
+                    if (createItineraryViewModel.validTitle(title)) {
+                      createItineraryViewModel.getNewItinerary()?.title(title)
                       true
                     } else {
                       createItineraryViewModel.getNewItinerary()?.title(null)
                       false
                     }
               },
-              maxLines = 2,
+              maxLines = 3,
               textStyle =
                   TextStyle(
                       fontSize = 22.sp,

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/creation/steps/CreationStepChooseTags.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/creation/steps/CreationStepChooseTags.kt
@@ -128,7 +128,7 @@ fun PriceEstimationTextBox(createItineraryViewModel: CreateItineraryViewModel) {
     mutableStateOf(createItineraryViewModel.getNewItinerary()!!.price?.toString() ?: "")
   }
 
-  val regex = "^[0-9]*\\.?[0-9]{2}$".toRegex()
+  val regex = "^[0-9]+(\\.[0-9]{0,2})?$".toRegex()
 
   Row(Modifier.fillMaxWidth().padding(all = 10.dp).clip(MaterialTheme.shapes.medium)) {
     TextField(

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/creation/steps/CreationStepPreviewBanner.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/creation/steps/CreationStepPreviewBanner.kt
@@ -39,10 +39,10 @@ fun CreationStepPreviewBanner(
   val onLikeButtonClick = { i: Itinerary, b: Boolean -> }
 
   Box(
-      modifier = Modifier.fillMaxSize().padding(horizontal = 10.dp, vertical = 0.dp),
+      modifier = Modifier.fillMaxSize().padding(horizontal = 10.dp, vertical = 5.dp),
       contentAlignment = Alignment.TopCenter) {
         LazyColumn(
-            verticalArrangement = spacedBy(15.dp),
+            verticalArrangement = spacedBy(8.dp),
             modifier = Modifier.testTag(TestTags.CREATION_SCREEN_PREVIEW_BANNER)) {
               item {
                 ItineraryBanner(

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
@@ -3,11 +3,9 @@ package com.github.wanderwise_inc.app.ui.itinerary
 import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -16,11 +14,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.HourglassEmpty
 import androidx.compose.material.icons.outlined.Payments
@@ -34,14 +30,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -194,8 +187,7 @@ fun BannerAttributes(itinerary: Itinerary, user: Profile?, numLikes: Int){
     Row(
         modifier =
         Modifier
-            .fillMaxHeight()
-            .padding(0.dp, 0.dp, 0.dp, 0.dp),
+            .fillMaxHeight(),
         horizontalArrangement = Arrangement.SpaceAround) {
         // Secondary indicator fields
         val textUser = user?.displayName ?: "-"
@@ -284,25 +276,36 @@ fun Likes(numLikes: Int){
 fun BannerLikeButton(modifier: Modifier, isLiked: Boolean, numLikes: Int,  itinerary: Itinerary, onClick: () -> Unit){
         // Like Icon
     Box(modifier = modifier.padding(5.dp)) {
-        Icon(
-            painter =
-            painterResource(
-                id =
-                if (isLiked) R.drawable.liked_icon_full
-                else R.drawable.liked_icon
-            ),
-            contentDescription = "like button heart icon",
-            tint = if (isLiked) Color.Red else MaterialTheme.colorScheme.secondary,
-            modifier =
-            Modifier
-                .testTag(
-                    "${TestTags.ITINERARY_BANNER_LIKE_BUTTON}_${itinerary.uid}"
-                )
-                .size(width = 40.dp, height = 40.dp)
-                .clickable(
-                    onClick = {
-                        onClick()
-                    })
-        )
+        ElevatedCard(
+            modifier = Modifier.size(35.dp, 35.dp),
+            elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,),
+            shape = CircleShape,
+            onClick = {onClick()}
+            ) {
+            Icon(
+                painter =
+                painterResource(
+                    id =
+                    if (isLiked) R.drawable.liked_icon_full
+                    else R.drawable.liked_icon
+                ),
+                contentDescription = "like button heart icon",
+                tint = if (isLiked) Color.Red else MaterialTheme.colorScheme.secondary,
+                modifier =
+                Modifier
+                    .testTag(
+                        "${TestTags.ITINERARY_BANNER_LIKE_BUTTON}_${itinerary.uid}"
+                    )
+//                    .size(width = 30.dp, height = 30.dp)
+                    .fillMaxSize()
+                    .padding(7.dp)
+//                    .clickable(
+//                        onClick = {
+//                            onClick()
+//                        })
+            )
+        }
     }
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.modifier.modifierLocalConsumer
@@ -96,7 +97,6 @@ fun ItineraryBanner(
   ElevatedCard(
       colors = CardDefaults.cardColors(
           containerColor = MaterialTheme.colorScheme.primaryContainer,
-          //containerColor = Color.Transparent
       ),
 
       elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
@@ -106,7 +106,7 @@ fun ItineraryBanner(
         Column(
             modifier =
             Modifier
-                .fillMaxWidth()
+                .fillMaxSize()
                 .aspectRatio(2f),
             horizontalAlignment = Alignment.CenterHorizontally) {
 
@@ -137,6 +137,7 @@ fun BannerImage(painter: AsyncImagePainter, itinerary : Itinerary){
         contentDescription = itinerary.description,
         modifier =
         Modifier.fillMaxSize(),
+            //.clip(RoundedCornerShape(16.dp)),
         contentScale = ContentScale.Crop,
         alignment = Alignment.TopCenter)
     if (painter.state is AsyncImagePainter.State.Loading) {
@@ -277,7 +278,7 @@ fun Likes(numLikes: Int){
 
 @Composable
 fun BannerLikeButton(modifier: Modifier, isLiked: Boolean, numLikes: Int,  itinerary: Itinerary, onClick: () -> Unit){
-        // Like Icon
+    // Like Icon
     Box(modifier = modifier.padding(5.dp)) {
         ElevatedCard(
             modifier = Modifier.size(35.dp, 35.dp),
@@ -301,13 +302,8 @@ fun BannerLikeButton(modifier: Modifier, isLiked: Boolean, numLikes: Int,  itine
                     .testTag(
                         "${TestTags.ITINERARY_BANNER_LIKE_BUTTON}_${itinerary.uid}"
                     )
-//                    .size(width = 30.dp, height = 30.dp)
                     .fillMaxSize()
                     .padding(7.dp)
-//                    .clickable(
-//                        onClick = {
-//                            onClick()
-//                        })
             )
         }
     }

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.HourglassEmpty
 import androidx.compose.material.icons.outlined.Payments
+import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
@@ -37,6 +38,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.modifier.modifierLocalConsumer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -92,10 +94,11 @@ fun ItineraryBanner(
   val user by profileViewModel.getProfile(itinerary.userUid).collectAsState(initial = null)
 
   ElevatedCard(
-      colors =
-          CardDefaults.cardColors(
-              containerColor = MaterialTheme.colorScheme.primaryContainer,
-          ),
+      colors = CardDefaults.cardColors(
+          containerColor = MaterialTheme.colorScheme.primaryContainer,
+          //containerColor = Color.Transparent
+      ),
+
       elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
       shape = RoundedCornerShape(13.dp),
       modifier = Modifier.testTag("${TestTags.ITINERARY_BANNER}_${itinerary.uid}"),
@@ -103,7 +106,6 @@ fun ItineraryBanner(
         Column(
             modifier =
             Modifier
-                .background(MaterialTheme.colorScheme.primaryContainer)
                 .fillMaxWidth()
                 .aspectRatio(2f),
             horizontalAlignment = Alignment.CenterHorizontally) {
@@ -121,10 +123,9 @@ fun ItineraryBanner(
                         isLiked = !isLiked}
                     BannerTags(itinerary, Modifier.align(Alignment.BottomStart))
                 }
-
                 BannerTitle(itinerary)
-
                 BannerAttributes(itinerary, user, numLikes)
+
             }
       }
 }
@@ -154,6 +155,7 @@ fun BannerTags(itinerary: Itinerary, modifier: Modifier){
 
         for (tag in itinerary.tags) {
             OutlinedCard(
+                shape = CircleShape,
                 colors =
                 CardDefaults.cardColors(
                     containerColor = MaterialTheme.colorScheme.secondaryContainer,
@@ -164,8 +166,9 @@ fun BannerTags(itinerary: Itinerary, modifier: Modifier){
                     textAlign = TextAlign.Center,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                     fontFamily = FontFamily.Monospace,
-                    fontSize = 12.sp,
-                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp))
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 10.sp,
+                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 0.dp))
             }
         }
     }
@@ -177,9 +180,9 @@ fun BannerTitle(itinerary: Itinerary){
         text = itinerary.title,
         color = MaterialTheme.colorScheme.onPrimaryContainer,
         fontFamily = FontFamily.Monospace,
-        fontSize = 16.sp,
+        fontSize = 14.sp,
         fontWeight = FontWeight.Bold,
-        modifier = Modifier.padding(2.dp))
+        modifier = Modifier)
 }
 
 @Composable
@@ -188,7 +191,7 @@ fun BannerAttributes(itinerary: Itinerary, user: Profile?, numLikes: Int){
         modifier =
         Modifier
             .fillMaxHeight(),
-        horizontalArrangement = Arrangement.SpaceAround) {
+        horizontalArrangement = Arrangement.SpaceBetween) {
         // Secondary indicator fields
         val textUser = user?.displayName ?: "-"
 
@@ -214,14 +217,14 @@ fun Time(time: Int){
             imageVector = Icons.Outlined.HourglassEmpty,
             contentDescription = "duration",
             tint = MaterialTheme.colorScheme.secondary,
-            modifier = Modifier.size(width = 20.dp, height = 20.dp))
+            modifier = Modifier.size(width = 16.dp, height = 16.dp))
         Text(
             text = "$time hours",
             color = MaterialTheme.colorScheme.secondary,
             fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
-            fontSize = 14.sp,
+            fontSize = 12.sp,
             fontWeight = FontWeight.Normal,
-            modifier = Modifier.padding(3.dp),
+            modifier = Modifier.padding(start = 2.dp),
             textAlign = TextAlign.Center,
         )
     }
@@ -236,14 +239,14 @@ fun Price(price: Float){
             imageVector = Icons.Outlined.Payments,
             contentDescription = "price",
             tint = MaterialTheme.colorScheme.secondary,
-            modifier = Modifier.size(width = 20.dp, height = 20.dp))
+            modifier = Modifier.size(width = 16.dp, height = 16.dp))
         Text(
             text = "${price}$",
             color = MaterialTheme.colorScheme.secondary,
             fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
-            fontSize = 14.sp,
+            fontSize = 12.sp,
             fontWeight = FontWeight.Normal,
-            modifier = Modifier.padding(3.dp),
+            modifier = Modifier.padding(start = 2.dp),
             textAlign = TextAlign.Center,
         )
     }
@@ -258,14 +261,14 @@ fun Likes(numLikes: Int){
             imageVector = Icons.Outlined.FavoriteBorder,
             contentDescription = "number of likes",
             tint = MaterialTheme.colorScheme.secondary,
-            modifier = Modifier.size(width = 20.dp, height = 20.dp))
+            modifier = Modifier.size(width = 16.dp, height = 16.dp))
         Text(
             text = "$numLikes likes",
             color = MaterialTheme.colorScheme.secondary,
             fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
-            fontSize = 14.sp,
+            fontSize = 12.sp,
             fontWeight = FontWeight.Normal,
-            modifier = Modifier.padding(3.dp),
+            modifier = Modifier.padding(start = 2.dp),
             textAlign = TextAlign.Center,
         )
     }

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
@@ -2,7 +2,6 @@ package com.github.wanderwise_inc.app.ui.itinerary
 
 import android.util.Log
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,7 +19,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.HourglassEmpty
 import androidx.compose.material.icons.outlined.Payments
-import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
@@ -36,10 +34,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.modifier.modifierLocalConsumer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -95,73 +91,64 @@ fun ItineraryBanner(
   val user by profileViewModel.getProfile(itinerary.userUid).collectAsState(initial = null)
 
   ElevatedCard(
-      colors = CardDefaults.cardColors(
-          containerColor = MaterialTheme.colorScheme.primaryContainer,
-      ),
-
+      colors =
+          CardDefaults.cardColors(
+              containerColor = MaterialTheme.colorScheme.primaryContainer,
+          ),
       elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
       shape = RoundedCornerShape(13.dp),
       modifier = Modifier.testTag("${TestTags.ITINERARY_BANNER}_${itinerary.uid}"),
       onClick = { onBannerClick(itinerary) }) {
         Column(
-            modifier =
-            Modifier
-                .fillMaxSize()
-                .aspectRatio(2f),
+            modifier = Modifier.fillMaxSize().aspectRatio(2f),
             horizontalAlignment = Alignment.CenterHorizontally) {
+              Box(modifier = Modifier.fillMaxWidth().fillMaxHeight(0.73f)) {
+                BannerImage(painter, itinerary)
 
-                Box(modifier = Modifier
-                    .fillMaxWidth()
-                    .fillMaxHeight(0.73f)
-                    //.clip(RoundedCornerShape(13.dp))
-                ){
-                    BannerImage(painter, itinerary)
-
-                    BannerLikeButton(modifier = Modifier.align(Alignment.TopEnd), isLiked = isLiked, numLikes = numLikes, itinerary = itinerary){
-                        if (isLiked) numLikes-- else numLikes++
-                        onLikeButtonClick(itinerary, isLiked)
-                        isLiked = !isLiked}
-                    BannerTags(itinerary, Modifier.align(Alignment.BottomStart))
-                }
-                BannerTitle(itinerary)
-                BannerAttributes(itinerary, user, numLikes)
-
+                BannerLikeButton(
+                    modifier = Modifier.align(Alignment.TopEnd),
+                    isLiked = isLiked,
+                    numLikes = numLikes,
+                    itinerary = itinerary) {
+                      if (isLiked) numLikes-- else numLikes++
+                      onLikeButtonClick(itinerary, isLiked)
+                      isLiked = !isLiked
+                    }
+                BannerTags(itinerary, Modifier.align(Alignment.BottomStart))
+              }
+              BannerTitle(itinerary)
+              BannerAttributes(itinerary, user, numLikes)
             }
       }
 }
 
 @Composable
-fun BannerImage(painter: AsyncImagePainter, itinerary : Itinerary){
-    Image(
-        painter = painter,
-        contentDescription = itinerary.description,
-        modifier =
-        Modifier.fillMaxSize(),
-            //.clip(RoundedCornerShape(16.dp)),
-        contentScale = ContentScale.Crop,
-        alignment = Alignment.TopCenter)
-    if (painter.state is AsyncImagePainter.State.Loading) {
-        CircularProgressIndicator()
-    }
+fun BannerImage(painter: AsyncImagePainter, itinerary: Itinerary) {
+  Image(
+      painter = painter,
+      contentDescription = itinerary.description,
+      modifier = Modifier.fillMaxSize(),
+      contentScale = ContentScale.Crop,
+      alignment = Alignment.TopCenter)
+  if (painter.state is AsyncImagePainter.State.Loading) {
+    CircularProgressIndicator()
+  }
 }
 
 @Composable
-fun BannerTags(itinerary: Itinerary, modifier: Modifier){
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(10.dp),
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-        verticalAlignment = Alignment.Bottom) {
-
+fun BannerTags(itinerary: Itinerary, modifier: Modifier) {
+  Row(
+      modifier = modifier.fillMaxWidth().padding(10.dp),
+      horizontalArrangement = Arrangement.spacedBy(10.dp),
+      verticalAlignment = Alignment.Bottom) {
         for (tag in itinerary.tags) {
-            OutlinedCard(
-                shape = CircleShape,
-                colors =
-                CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                ),
-                modifier = Modifier) {
+          OutlinedCard(
+              shape = CircleShape,
+              colors =
+                  CardDefaults.cardColors(
+                      containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                  ),
+              modifier = Modifier) {
                 Text(
                     text = tag,
                     textAlign = TextAlign.Center,
@@ -170,141 +157,128 @@ fun BannerTags(itinerary: Itinerary, modifier: Modifier){
                     fontWeight = FontWeight.Bold,
                     fontSize = 10.sp,
                     modifier = Modifier.padding(horizontal = 6.dp, vertical = 0.dp))
-            }
+              }
         }
-    }
+      }
 }
 
 @Composable
-fun BannerTitle(itinerary: Itinerary){
+fun BannerTitle(itinerary: Itinerary) {
+  Text(
+      text = itinerary.title,
+      color = MaterialTheme.colorScheme.onPrimaryContainer,
+      fontFamily = FontFamily.Monospace,
+      fontSize = 14.sp,
+      fontWeight = FontWeight.Bold,
+      modifier = Modifier)
+}
+
+@Composable
+fun BannerAttributes(itinerary: Itinerary, user: Profile?, numLikes: Int) {
+  Row(modifier = Modifier.fillMaxHeight(), horizontalArrangement = Arrangement.SpaceBetween) {
+    // Secondary indicator fields
+    val textUser = user?.displayName ?: "-"
+
+    Time(itinerary.time)
+
+    Spacer(modifier = Modifier.padding(10.dp))
+
+    Price(itinerary.price)
+
+    Spacer(modifier = Modifier.padding(10.dp))
+
+    Likes(numLikes = numLikes)
+  }
+}
+
+@Composable
+fun Time(time: Int) {
+  Row(horizontalArrangement = Arrangement.Center, verticalAlignment = Alignment.CenterVertically) {
+    Icon(
+        imageVector = Icons.Outlined.HourglassEmpty,
+        contentDescription = "duration",
+        tint = MaterialTheme.colorScheme.secondary,
+        modifier = Modifier.size(width = 16.dp, height = 16.dp))
     Text(
-        text = itinerary.title,
-        color = MaterialTheme.colorScheme.onPrimaryContainer,
-        fontFamily = FontFamily.Monospace,
-        fontSize = 14.sp,
-        fontWeight = FontWeight.Bold,
-        modifier = Modifier)
+        text = "$time hours",
+        color = MaterialTheme.colorScheme.secondary,
+        fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Normal,
+        modifier = Modifier.padding(start = 2.dp),
+        textAlign = TextAlign.Center,
+    )
+  }
 }
 
 @Composable
-fun BannerAttributes(itinerary: Itinerary, user: Profile?, numLikes: Int){
-    Row(
+fun Price(price: Float) {
+  Row(horizontalArrangement = Arrangement.Center, verticalAlignment = Alignment.CenterVertically) {
+    Icon(
+        imageVector = Icons.Outlined.Payments,
+        contentDescription = "price",
+        tint = MaterialTheme.colorScheme.secondary,
+        modifier = Modifier.size(width = 16.dp, height = 16.dp))
+    Text(
+        text = "${price}$",
+        color = MaterialTheme.colorScheme.secondary,
+        fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Normal,
+        modifier = Modifier.padding(start = 2.dp),
+        textAlign = TextAlign.Center,
+    )
+  }
+}
+
+@Composable
+fun Likes(numLikes: Int) {
+  Row(horizontalArrangement = Arrangement.Center, verticalAlignment = Alignment.CenterVertically) {
+    Icon(
+        imageVector = Icons.Outlined.FavoriteBorder,
+        contentDescription = "number of likes",
+        tint = MaterialTheme.colorScheme.secondary,
+        modifier = Modifier.size(width = 16.dp, height = 16.dp))
+    Text(
+        text = "$numLikes likes",
+        color = MaterialTheme.colorScheme.secondary,
+        fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Normal,
+        modifier = Modifier.padding(start = 2.dp),
+        textAlign = TextAlign.Center,
+    )
+  }
+}
+
+@Composable
+fun BannerLikeButton(
+    modifier: Modifier,
+    isLiked: Boolean,
+    numLikes: Int,
+    itinerary: Itinerary,
+    onClick: () -> Unit
+) {
+  // Like Icon
+  Box(modifier = modifier.padding(5.dp)) {
+    ElevatedCard(
         modifier =
-        Modifier
-            .fillMaxHeight(),
-        horizontalArrangement = Arrangement.SpaceBetween) {
-        // Secondary indicator fields
-        val textUser = user?.displayName ?: "-"
-
-        Time(itinerary.time)
-        
-        Spacer(modifier = Modifier.padding(10.dp))
-
-        Price(itinerary.price)
-
-        Spacer(modifier = Modifier.padding(10.dp))
-
-        Likes(numLikes = numLikes)
-
-    }
-}
-
-@Composable
-fun Time(time: Int){
-    Row(
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically) {
-        Icon(
-            imageVector = Icons.Outlined.HourglassEmpty,
-            contentDescription = "duration",
-            tint = MaterialTheme.colorScheme.secondary,
-            modifier = Modifier.size(width = 16.dp, height = 16.dp))
-        Text(
-            text = "$time hours",
-            color = MaterialTheme.colorScheme.secondary,
-            fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
-            fontSize = 12.sp,
-            fontWeight = FontWeight.Normal,
-            modifier = Modifier.padding(start = 2.dp),
-            textAlign = TextAlign.Center,
-        )
-    }
-}
-
-@Composable
-fun Price(price: Float){
-    Row(
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically) {
-        Icon(
-            imageVector = Icons.Outlined.Payments,
-            contentDescription = "price",
-            tint = MaterialTheme.colorScheme.secondary,
-            modifier = Modifier.size(width = 16.dp, height = 16.dp))
-        Text(
-            text = "${price}$",
-            color = MaterialTheme.colorScheme.secondary,
-            fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
-            fontSize = 12.sp,
-            fontWeight = FontWeight.Normal,
-            modifier = Modifier.padding(start = 2.dp),
-            textAlign = TextAlign.Center,
-        )
-    }
-}
-
-@Composable
-fun Likes(numLikes: Int){
-    Row(
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically) {
-        Icon(
-            imageVector = Icons.Outlined.FavoriteBorder,
-            contentDescription = "number of likes",
-            tint = MaterialTheme.colorScheme.secondary,
-            modifier = Modifier.size(width = 16.dp, height = 16.dp))
-        Text(
-            text = "$numLikes likes",
-            color = MaterialTheme.colorScheme.secondary,
-            fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
-            fontSize = 12.sp,
-            fontWeight = FontWeight.Normal,
-            modifier = Modifier.padding(start = 2.dp),
-            textAlign = TextAlign.Center,
-        )
-    }
-}
-
-
-@Composable
-fun BannerLikeButton(modifier: Modifier, isLiked: Boolean, numLikes: Int,  itinerary: Itinerary, onClick: () -> Unit){
-    // Like Icon
-    Box(modifier = modifier.padding(5.dp)) {
-        ElevatedCard(
-            modifier = Modifier.size(35.dp, 35.dp),
-            elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.primaryContainer,),
-            shape = CircleShape,
-            onClick = {onClick()}
-            ) {
-            Icon(
-                painter =
-                painterResource(
-                    id =
-                    if (isLiked) R.drawable.liked_icon_full
-                    else R.drawable.liked_icon
-                ),
-                contentDescription = "like button heart icon",
-                tint = if (isLiked) Color.Red else MaterialTheme.colorScheme.secondary,
-                modifier =
-                Modifier
-                    .testTag(
-                        "${TestTags.ITINERARY_BANNER_LIKE_BUTTON}_${itinerary.uid}"
-                    )
-                    .fillMaxSize()
-                    .padding(7.dp)
-            )
+            Modifier.size(35.dp, 35.dp)
+                .testTag("${TestTags.ITINERARY_BANNER_LIKE_BUTTON}_${itinerary.uid}"),
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+            ),
+        shape = CircleShape,
+        onClick = { onClick() }) {
+          Icon(
+              painter =
+                  painterResource(
+                      id = if (isLiked) R.drawable.liked_icon_full else R.drawable.liked_icon),
+              contentDescription = "like button heart icon",
+              tint = if (isLiked) Color.Red else MaterialTheme.colorScheme.secondary,
+              modifier = Modifier.fillMaxSize().padding(7.dp))
         }
-    }
+  }
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
@@ -181,13 +181,13 @@ fun BannerAttributes(itinerary: Itinerary, user: Profile?, numLikes: Int) {
 
     Time(itinerary.time)
 
-    Spacer(modifier = Modifier.padding(10.dp))
+    Spacer(Modifier.padding(10.dp))
 
     Price(itinerary.price)
 
-    Spacer(modifier = Modifier.padding(10.dp))
+    Spacer(Modifier.padding(10.dp))
 
-    Likes(numLikes = numLikes)
+    Likes(numLikes)
   }
 }
 
@@ -220,7 +220,7 @@ fun Price(price: Float) {
         tint = MaterialTheme.colorScheme.secondary,
         modifier = Modifier.size(width = 16.dp, height = 16.dp))
     Text(
-        text = "${price}$",
+        text = "${price}",
         color = MaterialTheme.colorScheme.secondary,
         fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
         fontSize = 12.sp,
@@ -255,7 +255,7 @@ fun Likes(numLikes: Int) {
 fun BannerLikeButton(
     modifier: Modifier,
     isLiked: Boolean,
-    numLikes: Int,
+    numLikes: Int, // an argument is needed to be sent on change for it to recompose.
     itinerary: Itinerary,
     onClick: () -> Unit
 ) {

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/itinerary/ItineraryBanner.kt
@@ -5,9 +5,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -17,6 +19,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.HourglassEmpty
+import androidx.compose.material.icons.outlined.Payments
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
@@ -50,6 +55,7 @@ import coil.request.ImageRequest
 import com.github.wanderwise_inc.app.R
 import com.github.wanderwise_inc.app.data.ImageRepository
 import com.github.wanderwise_inc.app.model.location.Itinerary
+import com.github.wanderwise_inc.app.model.profile.Profile
 import com.github.wanderwise_inc.app.ui.TestTags
 import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
 
@@ -87,8 +93,8 @@ fun ItineraryBanner(
   val painter = rememberAsyncImagePainter(model = model)
   var isLiked = isLikedInitially
   var numLikes by remember { mutableIntStateOf(itinerary.numLikes) }
-  var prices by remember { mutableFloatStateOf(itinerary.price) }
-  var times by remember { mutableIntStateOf(itinerary.time) }
+//  var prices by remember { mutableFloatStateOf(itinerary.price) }
+//  var times by remember { mutableIntStateOf(itinerary.time) }
   val user by profileViewModel.getProfile(itinerary.userUid).collectAsState(initial = null)
 
   ElevatedCard(
@@ -102,87 +108,41 @@ fun ItineraryBanner(
       onClick = { onBannerClick(itinerary) }) {
         Column(
             modifier =
-                Modifier.background(MaterialTheme.colorScheme.primaryContainer)
-                    .fillMaxWidth()
-                    .aspectRatio(1.34f),
+            Modifier
+                .background(MaterialTheme.colorScheme.primaryContainer)
+                .fillMaxWidth()
+                .aspectRatio(1.34f),
             horizontalAlignment = Alignment.CenterHorizontally) {
-              Image(
-                  painter = painter,
-                  contentDescription = itinerary.description,
-                  modifier =
-                      Modifier.fillMaxWidth().fillMaxHeight(0.55f).clip(RoundedCornerShape(13.dp)),
-                  contentScale = ContentScale.Crop,
-                  alignment = Alignment.TopCenter)
-              if (painter.state is AsyncImagePainter.State.Loading) {
-                CircularProgressIndicator()
-              }
-              // Image of the itinerary
-              // Primary Text Field
-              Text(
-                  text = itinerary.title,
-                  color = MaterialTheme.colorScheme.onPrimaryContainer,
-                  fontFamily = FontFamily.Monospace,
-                  fontSize = 14.sp,
-                  fontWeight = FontWeight.Bold,
-                  modifier = Modifier.padding(2.dp))
+
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight(0.55f)
+                    .clip(RoundedCornerShape(13.dp))){
+                    BannerImage(painter, itinerary)
+                    BannerTags(itinerary, Modifier.align(Alignment.BottomCenter))
+                }
+
+                BannerTitle(itinerary)
+
+                Spacer(Modifier.padding(5.dp))
 
               Row(modifier = Modifier.fillMaxSize()) {
-                Column(
-                    modifier =
-                        Modifier.fillMaxHeight().weight(0.7f).padding(10.dp, 4.dp, 4.dp, 15.dp),
-                    verticalArrangement = Arrangement.SpaceAround) {
-                      // Secondary indicator fields
-                      val textUser = if (user != null) user!!.displayName else "-"
-                      Text(
-                          text = "Wandered by $textUser",
-                          color = MaterialTheme.colorScheme.secondary,
-                          fontFamily = FontFamily.Monospace,
-                          fontSize = 12.sp,
-                          modifier = Modifier.padding(4.dp, 0.dp))
 
-                      Text(
-                          text = "Estimated time: $times hours",
-                          color = MaterialTheme.colorScheme.secondary,
-                          fontFamily = FontFamily.Monospace,
-                          fontSize = 12.sp,
-                          modifier = Modifier.padding(4.dp, 0.dp))
+                  BannerAttributes(itinerary, user)
 
-                      Text(
-                          text = "Average Expense: $prices",
-                          color = MaterialTheme.colorScheme.secondary,
-                          fontFamily = FontFamily.Monospace,
-                          fontSize = 12.sp,
-                          modifier = Modifier.padding(4.dp, 0.dp))
-                    }
                 Column(
-                    modifier = Modifier.weight(0.3f).fillMaxSize().padding(4.dp, 2.dp, 10.dp, 2.dp),
+                    modifier = Modifier
+                        .weight(0.3f)
+                        .fillMaxSize()
+                        .padding(4.dp, 2.dp, 10.dp, 2.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.SpaceBetween,
                 ) {
-                  LazyRow(
-                      modifier = Modifier.fillMaxWidth().weight(0.3f).padding(2.dp),
-                      contentPadding = PaddingValues(horizontal = 2.dp, vertical = 5.dp),
-                      horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                        items(itinerary.tags) {
-                          OutlinedCard(
-                              colors =
-                                  CardDefaults.cardColors(
-                                      containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                  ),
-                              modifier = Modifier.fillMaxWidth()) {
-                                Text(
-                                    text = it,
-                                    textAlign = TextAlign.Center,
-                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                                    fontFamily = FontFamily.Monospace,
-                                    fontSize = 12.sp,
-                                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp))
-                              }
-                        }
-                      }
 
                   Column(
-                      modifier = Modifier.fillMaxWidth().weight(0.5f),
+                      modifier = Modifier
+                          .fillMaxWidth()
+                          .weight(0.5f),
                       horizontalAlignment = Alignment.CenterHorizontally) {
                         // Like Icon
                         Icon(
@@ -194,15 +154,17 @@ fun ItineraryBanner(
                             contentDescription = "like button heart icon",
                             tint = if (isLiked) Color.Red else MaterialTheme.colorScheme.secondary,
                             modifier =
-                                Modifier.testTag(
-                                        "${TestTags.ITINERARY_BANNER_LIKE_BUTTON}_${itinerary.uid}")
-                                    .size(width = 40.dp, height = 40.dp)
-                                    .clickable(
-                                        onClick = {
-                                          if (isLiked) numLikes-- else numLikes++
-                                          onLikeButtonClick(itinerary, isLiked)
-                                          isLiked = !isLiked
-                                        }))
+                            Modifier
+                                .testTag(
+                                    "${TestTags.ITINERARY_BANNER_LIKE_BUTTON}_${itinerary.uid}"
+                                )
+                                .size(width = 40.dp, height = 40.dp)
+                                .clickable(
+                                    onClick = {
+                                        if (isLiked) numLikes-- else numLikes++
+                                        onLikeButtonClick(itinerary, isLiked)
+                                        isLiked = !isLiked
+                                    }))
 
                         Text(
                             text = "$numLikes Likes",
@@ -215,4 +177,141 @@ fun ItineraryBanner(
               }
             }
       }
+}
+
+@Composable
+fun BannerImage(painter: AsyncImagePainter, itinerary : Itinerary){
+    Image(
+        painter = painter,
+        contentDescription = itinerary.description,
+        modifier =
+        Modifier.fillMaxSize(),
+        contentScale = ContentScale.Crop,
+        alignment = Alignment.TopCenter)
+    if (painter.state is AsyncImagePainter.State.Loading) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+fun BannerTags(itinerary: Itinerary, modifier: Modifier){
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(10.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.Bottom) {
+
+        for (tag in itinerary.tags) {
+            OutlinedCard(
+                colors =
+                CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                ),
+                modifier = Modifier) {
+                Text(
+                    text = tag,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 12.sp,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp))
+            }
+        }
+    }
+}
+
+@Composable
+fun BannerTitle(itinerary: Itinerary){
+    Text(
+        text = itinerary.title,
+        color = MaterialTheme.colorScheme.onPrimaryContainer,
+        fontFamily = FontFamily.Monospace,
+        fontSize = 16.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(2.dp))
+}
+
+@Composable
+fun BannerAttributes(itinerary: Itinerary, user: Profile?){
+    Row(
+        modifier =
+        Modifier
+            .fillMaxHeight()
+            .padding(10.dp, 4.dp, 4.dp, 15.dp),
+        horizontalArrangement = Arrangement.SpaceAround) {
+        // Secondary indicator fields
+        val textUser = user?.displayName ?: "-"
+//        Text(
+//            text = "Wandered by $textUser",
+//            color = MaterialTheme.colorScheme.secondary,
+//            fontFamily = FontFamily.Monospace,
+//            fontSize = 12.sp,
+//            modifier = Modifier.padding(4.dp, 0.dp))
+
+//        Text(
+//            text = "Estimated time: ${itinerary.time} hours",
+//            color = MaterialTheme.colorScheme.secondary,
+//            fontFamily = FontFamily.Monospace,
+//            fontSize = 12.sp,
+//            modifier = Modifier.padding(4.dp, 0.dp))
+        Spacer(Modifier.padding(10.dp))
+
+        Time(itinerary.time)
+        
+        Spacer(modifier = Modifier.padding(10.dp))
+
+        Price(itinerary.price)
+
+//        Text(
+//            text = "Average Expense: ${itinerary.price}",
+//            color = MaterialTheme.colorScheme.secondary,
+//            fontFamily = FontFamily.Monospace,
+//            fontSize = 16.sp,
+//            modifier = Modifier.padding(4.dp, 0.dp))
+    }
+}
+
+@Composable
+fun Time(time: Int){
+    Row(
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            imageVector = Icons.Outlined.HourglassEmpty,
+            contentDescription = "duration",
+            tint = MaterialTheme.colorScheme.secondary,
+            modifier = Modifier.size(width = 25.dp, height = 25.dp))
+        Text(
+            text = "$time hours",
+            color = MaterialTheme.colorScheme.secondary,
+            fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Normal,
+            modifier = Modifier.padding(3.dp),
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+fun Price(price: Float){
+    Row(
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            imageVector = Icons.Outlined.Payments,
+            contentDescription = "price",
+            tint = MaterialTheme.colorScheme.secondary,
+            modifier = Modifier.size(width = 25.dp, height = 25.dp))
+        Text(
+            text = "${price}$",
+            color = MaterialTheme.colorScheme.secondary,
+            fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Normal,
+            modifier = Modifier.padding(3.dp),
+            textAlign = TextAlign.Center,
+        )
+    }
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/ItineraryList.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/ItineraryList.kt
@@ -83,7 +83,13 @@ fun ItinerariesListScrollable(
             .collectAsState(initial = emptyList())
 
     LazyColumn(
-        modifier = Modifier.padding(start = 10.dp, top = paddingValues.calculateTopPadding() + 5.dp, end = 10.dp, bottom = paddingValues.calculateBottomPadding()).testTag(TestTags.ITINERARY_LIST_SCROLLABLE),
+        modifier =
+            Modifier.padding(
+                    start = 10.dp,
+                    top = paddingValues.calculateTopPadding() + 5.dp,
+                    end = 10.dp,
+                    bottom = paddingValues.calculateBottomPadding())
+                .testTag(TestTags.ITINERARY_LIST_SCROLLABLE),
         verticalArrangement = spacedBy(8.dp)) {
           this.items(itineraries, key = { it.uid }) { itinerary ->
             val uid = profileViewModel.getUserUid()
@@ -121,7 +127,7 @@ fun ItinerariesListScrollable(
                 imageRepository = imageRepository)
           }
 
-            item {Spacer(Modifier.padding(20.dp))}
+          item { Spacer(Modifier.padding(20.dp)) }
         }
   }
   var offlineHintVisible by remember {

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/ItineraryList.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/ItineraryList.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -82,8 +83,8 @@ fun ItinerariesListScrollable(
             .collectAsState(initial = emptyList())
 
     LazyColumn(
-        modifier = Modifier.padding(paddingValues).testTag(TestTags.ITINERARY_LIST_SCROLLABLE),
-        verticalArrangement = spacedBy(15.dp)) {
+        modifier = Modifier.padding(start = 10.dp, top = paddingValues.calculateTopPadding() + 5.dp, end = 10.dp, bottom = paddingValues.calculateBottomPadding()).testTag(TestTags.ITINERARY_LIST_SCROLLABLE),
+        verticalArrangement = spacedBy(8.dp)) {
           this.items(itineraries, key = { it.uid }) { itinerary ->
             val uid = profileViewModel.getUserUid()
             var isLikedInitially by remember {
@@ -119,6 +120,8 @@ fun ItinerariesListScrollable(
                 profileViewModel = profileViewModel,
                 imageRepository = imageRepository)
           }
+
+            item {Spacer(Modifier.padding(20.dp))}
         }
   }
   var offlineHintVisible by remember {

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/LikedScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/LikedScreen.kt
@@ -5,10 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.HourglassEmpty
 import androidx.compose.material.icons.outlined.Save
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -25,7 +22,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.github.wanderwise_inc.app.R
@@ -97,9 +93,7 @@ fun DisplayLikedItineraries(
       topBar = {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag(TestTags.CATEGORY_SELECTOR)) {
+            modifier = Modifier.fillMaxWidth().testTag(TestTags.CATEGORY_SELECTOR)) {
               SearchBar(
                   onSearchChange = { searchQuery = it },
                   onPriceChange = { priceRange = it },
@@ -113,16 +107,14 @@ fun DisplayLikedItineraries(
             }
       },
       floatingActionButton = {
-          FloatingActionButton(
+        FloatingActionButton(
             onClick = { itineraryViewModel.saveItineraries(itineraries) },
             containerColor = MaterialTheme.colorScheme.secondaryContainer) {
               Icon(
                   imageVector = Icons.Outlined.Save,
                   contentDescription = "Save Itineraries",
                   tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                  modifier = Modifier
-                      .size(40.dp)
-                      .padding(2.dp))
+                  modifier = Modifier.size(40.dp).padding(2.dp))
             }
       },
       modifier = Modifier.testTag(TestTags.LIKED_SCREEN)) { innerPadding ->

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/LikedScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/list_itineraries/LikedScreen.kt
@@ -4,8 +4,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.HourglassEmpty
+import androidx.compose.material.icons.outlined.Save
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -93,7 +97,9 @@ fun DisplayLikedItineraries(
       topBar = {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.fillMaxWidth().testTag(TestTags.CATEGORY_SELECTOR)) {
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(TestTags.CATEGORY_SELECTOR)) {
               SearchBar(
                   onSearchChange = { searchQuery = it },
                   onPriceChange = { priceRange = it },
@@ -107,16 +113,16 @@ fun DisplayLikedItineraries(
             }
       },
       floatingActionButton = {
-        Button(
+          FloatingActionButton(
             onClick = { itineraryViewModel.saveItineraries(itineraries) },
-            colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer)) {
+            containerColor = MaterialTheme.colorScheme.secondaryContainer) {
               Icon(
-                  painter = painterResource(R.drawable.floppy_disk),
+                  imageVector = Icons.Outlined.Save,
                   contentDescription = "Save Itineraries",
                   tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                  modifier = Modifier.size(30.dp).padding(2.dp))
+                  modifier = Modifier
+                      .size(40.dp)
+                      .padding(2.dp))
             }
       },
       modifier = Modifier.testTag(TestTags.LIKED_SCREEN)) { innerPadding ->

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
@@ -385,7 +385,7 @@ private fun PreviewItineraryBannerMaximized(
                 onClick = {
                   coroutineScope.launch {
                     imageRepository.deleteImageFromStorage("itineraryPictures/${itinerary.uid}")
-                      itineraryViewModel.setFocusedItinerary(null)
+                    itineraryViewModel.setFocusedItinerary(null)
                     itineraryViewModel.deleteItinerary(itinerary)
                   }
                   NavigationActions(navController)

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
@@ -385,6 +385,7 @@ private fun PreviewItineraryBannerMaximized(
                 onClick = {
                   coroutineScope.launch {
                     imageRepository.deleteImageFromStorage("itineraryPictures/${itinerary.uid}")
+                      itineraryViewModel.setFocusedItinerary(null)
                     itineraryViewModel.deleteItinerary(itinerary)
                   }
                   NavigationActions(navController)

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/profile/ProfileScreen.kt
@@ -128,7 +128,7 @@ fun ProfileScreen(
                   itineraryViewModel = itineraryViewModel,
                   profileViewModel = profileViewModel,
                   navController = navHostController,
-                  paddingValues = PaddingValues(8.dp),
+                  paddingValues = PaddingValues(0.dp),
                   parent = ItineraryListParent.PROFILE,
                   imageRepository = imageRepository)
             }

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/CreateItineraryViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/CreateItineraryViewModel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
-const val TITLE_MAX_LENGTH = 80
+const val TITLE_MAX_LENGTH = 43
 
 class CreateItineraryViewModel(
     itineraryRepository: ItineraryRepository,


### PR DESCRIPTION
closes #330 

# New look for ItinearyBanners
![Screenshot from 2024-05-22 17-32-58](https://github.com/WanderWise-Inc/app/assets/100207698/502d3f2a-20d4-4ee2-92a7-5fc28086fa3d)

## What has been done
- new look for ItineraryBanners
- the code has been written in a modular fashion making it easy to edit  and less cognitive complexity
- added padding to ItinerariesList
- changed save button to FloatingActionButton (better looking)
- deleting and itinerary set ItineraryViewModels focusedItinerary to null
- title max length set to 43  characters (value found through writing "W" multiple times until there wasn't enough space)
- no more '\n' allowed in titles
- fixed error with tags screen price regex (oops...)

## things to take into account
- the color theme hasn't been changed yet therefore colors are very weird
-  more suited to a smartphone
- better for long titles
- I know some people are unhappy with the change however, It is important to understand that banners main use is for browsing, having less information per banners and having more of them on one page helps achieving this goal.

## Conclusion
The new banners are better at serving their purpose of making people want to click on them, some adjustments are needed such as the color scheme or even maybe resizing fields to make them "perfect".
To the person reading this that is very unhappy with the new and **improved** look , the way the code is written makes it very easy to modify in the future if G.Fleicher agrees with you.
