### PR TITLE
Itineray optimal zoom-level + bugfix in PreviewItineraryScreen

### DIFF
--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
@@ -93,9 +93,13 @@ fun PreviewItineraryScreen(
   if (itinerary == null) {
     NullItinerary(userLocation)
   } else {
-    val cameraPositionState = rememberCameraPositionState {
-      position = CameraPosition.fromLatLngZoom(itinerary.computeCenterOfGravity().toLatLng(), 13f)
-    }
+    val cameraPositionState =
+        rememberCameraPositionState(key = itinerary.toString()) {
+          position =
+              CameraPosition.fromLatLngZoom(
+                  itinerary.computeCenterOfGravity().toLatLng(),
+                  itinerary.computeOptimalZoomLevel())
+        }
 
     LaunchedEffect(Unit) { itineraryViewModel.fetchPolylineLocations(itinerary) }
     val polylinePoints by itineraryViewModel.getPolylinePointsLiveData().observeAsState()


### PR DESCRIPTION
# Closes #285, #289

- `Itinerary` method for computing optimal zoom level
- `PreviewItinerary` calls this method for computing the maps composable zoom-level
- bug fix for `PreviewItinerary` that wasn't re-centering after changing focused itinerary

# Example use case: huge itinerary that wouldn't have been visible before

![Screenshot from 2024-05-23 11-53-36](https://github.com/WanderWise-Inc/app/assets/100317390/e9a2ed7e-6efb-49ba-86b1-b8f5c9c15dbd)


