### PR TITLE
Fixed center button and changed a few more things

### DIFF
--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
@@ -70,7 +70,6 @@ import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.maps.android.compose.AdvancedMarker
-import com.google.maps.android.compose.CameraPositionState
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.MarkerState
@@ -90,9 +89,7 @@ fun PreviewItineraryScreen(
   val itinerary = itineraryViewModel.getFocusedItinerary()
   val context = LocalContext.current
 
-  val followItinerary = {
-      itineraryViewModel.followItineraryOnGoogleMaps(context, itinerary!!)
-  }
+  val followItinerary = { itineraryViewModel.followItineraryOnGoogleMaps(context, itinerary!!) }
 
   if (itinerary == null) {
     NullItinerary(userLocation)
@@ -108,16 +105,14 @@ fun PreviewItineraryScreen(
 
     // pressing on center button changed centerOnUser variable which launches camera movement
     LaunchedEffect(centeredOnUser) {
-        cameraPositionState.move(
-            if (centeredOnUser && userLocation!= null) {
-                val latLng = userLocation!!.toLatLng()
-                CameraUpdateFactory.newLatLngZoom(latLng, 13f)
-            } else {
-                CameraUpdateFactory.newLatLngZoom(
-                    itinerary.computeCenterOfGravity().toLatLng(),
-                    itinerary.computeOptimalZoomLevel())
-            }
-        )
+      cameraPositionState.move(
+          if (centeredOnUser && userLocation != null) {
+            val latLng = userLocation!!.toLatLng()
+            CameraUpdateFactory.newLatLngZoom(latLng, 13f)
+          } else {
+            CameraUpdateFactory.newLatLngZoom(
+                itinerary.computeCenterOfGravity().toLatLng(), itinerary.computeOptimalZoomLevel())
+          })
     }
 
     LaunchedEffect(Unit) { itineraryViewModel.fetchPolylineLocations(itinerary) }
@@ -138,71 +133,61 @@ fun PreviewItineraryScreen(
         },
         modifier = Modifier.testTag(TestTags.MAP_PREVIEW_ITINERARY_SCREEN),
         floatingActionButton = {
-          CenterButton(/*cameraPositionState = cameraPositionState, currentLocation = userLocation*/ {centeredOnUser = !centeredOnUser})
+          CenterButton(
+              /*cameraPositionState = cameraPositionState, currentLocation = userLocation*/ {
+            centeredOnUser = !centeredOnUser
+          })
         },
         floatingActionButtonPosition = FabPosition.Start) { paddingValues ->
           Box {
-              GoogleMap(
-                  modifier =
-                  Modifier
-                      .fillMaxSize()
-                      .padding(paddingValues)
-                      .testTag(TestTags.MAP_GOOGLE_MAPS),
-                  cameraPositionState = cameraPositionState
-              ) {
+            GoogleMap(
+                modifier =
+                    Modifier.fillMaxSize().padding(paddingValues).testTag(TestTags.MAP_GOOGLE_MAPS),
+                cameraPositionState = cameraPositionState) {
                   userLocation?.let {
-                      Marker(
-                          tag = TestTags.MAP_USER_LOCATION,
-                          state = MarkerState(position = it.toLatLng()),
-                          icon =
-                          BitmapDescriptorFactory.defaultMarker(
-                              BitmapDescriptorFactory.HUE_AZURE
-                          )
-                      )
+                    Marker(
+                        tag = TestTags.MAP_USER_LOCATION,
+                        state = MarkerState(position = it.toLatLng()),
+                        icon =
+                            BitmapDescriptorFactory.defaultMarker(
+                                BitmapDescriptorFactory.HUE_AZURE))
                   }
                   itinerary.locations.map { location ->
-                      AdvancedMarker(
-                          state = MarkerState(position = location.toLatLng()),
-                          title = location.title,
-                      )
-                      if (polylinePoints != null) {
-                          Polyline(
-                              points = polylinePoints!!,
-                              color = MaterialTheme.colorScheme.primary
-                          )
-                      }
+                    AdvancedMarker(
+                        state = MarkerState(position = location.toLatLng()),
+                        title = location.title,
+                    )
+                    if (polylinePoints != null) {
+                      Polyline(points = polylinePoints!!, color = MaterialTheme.colorScheme.primary)
+                    }
                   }
-              }
-              FollowItineraryButton(
-                  followItinerary,
-                  Modifier.align(Alignment.TopCenter) // this parameter allows alignment wrt containing Box composable
-              )
+                }
+            FollowItineraryButton(
+                followItinerary,
+                Modifier.align(
+                    Alignment
+                        .TopCenter) // this parameter allows alignment wrt containing Box composable
+                )
           }
         }
   }
 }
 
-/**
- * @brief: Button which launches google maps with specified itinerary once pressed
- */
+/** @brief: Button which launches google maps with specified itinerary once pressed */
 @Composable
 fun FollowItineraryButton(followItinerary: () -> Unit, modifier: Modifier) {
-    ExtendedFloatingActionButton(
-        onClick = { followItinerary() },
-        icon = {
-            Icon(
-                Icons.AutoMirrored.Filled.DirectionsWalk,
-                contentDescription = "follow",
-                modifier = Modifier.size(32.dp))
-        },
-        text = {
-            Text(text = "Follow", color = Color.DarkGray)
-        },
-        containerColor = MaterialTheme.colorScheme.secondaryContainer,
-        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-        modifier = modifier
-            .padding(12.dp)
-            .testTag(TestTags.START_NEW_ITINERARY_STARTING))
+  ExtendedFloatingActionButton(
+      onClick = { followItinerary() },
+      icon = {
+        Icon(
+            Icons.AutoMirrored.Filled.DirectionsWalk,
+            contentDescription = "follow",
+            modifier = Modifier.size(32.dp))
+      },
+      text = { Text(text = "Follow", color = Color.DarkGray) },
+      containerColor = MaterialTheme.colorScheme.secondaryContainer,
+      contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+      modifier = modifier.padding(12.dp).testTag(TestTags.START_NEW_ITINERARY_STARTING))
 }
 
 /**
@@ -246,10 +231,7 @@ private fun PreviewItineraryBannerMaximized(
   val ctr = remember { mutableIntStateOf(0) }
 
   val profilePictureModifier =
-      Modifier
-          .clip(RoundedCornerShape(5.dp))
-          .size(50.dp)
-          .testTag(TestTags.MAP_PROFILE_PIC)
+      Modifier.clip(RoundedCornerShape(5.dp)).size(50.dp).testTag(TestTags.MAP_PROFILE_PIC)
 
   val profile by profileViewModel.getProfile(itinerary.userUid).collectAsState(initial = null)
 
@@ -262,12 +244,11 @@ private fun PreviewItineraryBannerMaximized(
         val scrollState = rememberScrollState()
         Column(
             modifier =
-            Modifier
-                .background(MaterialTheme.colorScheme.primaryContainer)
-                .fillMaxWidth()
-                .aspectRatio(1.2f)
-                .padding(30.dp)
-                .verticalScroll(scrollState),
+                Modifier.background(MaterialTheme.colorScheme.primaryContainer)
+                    .fillMaxWidth()
+                    .aspectRatio(1.2f)
+                    .padding(30.dp)
+                    .verticalScroll(scrollState),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Top,
         ) {
@@ -277,9 +258,7 @@ private fun PreviewItineraryBannerMaximized(
                 imageVector = Icons.Filled.KeyboardArrowDown,
                 contentDescription = "minimize_button",
                 modifier =
-                Modifier
-                    .clickable { onMinimizedClick() }
-                    .testTag(TestTags.MAP_BANNER_BUTTON))
+                    Modifier.clickable { onMinimizedClick() }.testTag(TestTags.MAP_BANNER_BUTTON))
             // Itinerary Title
             Text(
                 text = itinerary.title,
@@ -287,9 +266,7 @@ private fun PreviewItineraryBannerMaximized(
                 fontFamily = MaterialTheme.typography.displayLarge.fontFamily,
                 fontSize = titleFontSize,
                 fontWeight = FontWeight.Normal,
-                modifier = Modifier
-                    .padding(2.dp)
-                    .testTag(TestTags.MAP_ITINERARY_TITLE),
+                modifier = Modifier.padding(2.dp).testTag(TestTags.MAP_ITINERARY_TITLE),
                 textAlign = TextAlign.Center)
           }
 
@@ -401,9 +378,7 @@ private fun PreviewItineraryBannerMaximized(
                   fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
                   fontSize = innerFontSize,
                   fontWeight = FontWeight.Light,
-                  modifier = Modifier
-                      .padding(2.dp)
-                      .fillMaxHeight(),
+                  modifier = Modifier.padding(2.dp).fillMaxHeight(),
                   textAlign = TextAlign.Center,
               )
             }
@@ -422,9 +397,7 @@ private fun PreviewItineraryBannerMaximized(
                 fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Normal,
-                modifier = Modifier
-                    .padding(2.dp)
-                    .testTag(TestTags.MAP_ITINERARY_DESCRIPTION),
+                modifier = Modifier.padding(2.dp).testTag(TestTags.MAP_ITINERARY_DESCRIPTION),
                 textAlign = TextAlign.Center)
           }
           Spacer(modifier = Modifier.height(20.dp))
@@ -466,11 +439,10 @@ private fun PreviewItineraryBannerMinimized(onMinimizedClick: () -> Unit, itiner
       modifier = Modifier.testTag(TestTags.MAP_MINIMIZED_BANNER)) {
         Column(
             modifier =
-            Modifier
-                .background(MaterialTheme.colorScheme.primaryContainer)
-                .fillMaxWidth()
-                .aspectRatio(3f)
-                .padding(30.dp),
+                Modifier.background(MaterialTheme.colorScheme.primaryContainer)
+                    .fillMaxWidth()
+                    .aspectRatio(3f)
+                    .padding(30.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
           Row {
@@ -479,9 +451,7 @@ private fun PreviewItineraryBannerMinimized(onMinimizedClick: () -> Unit, itiner
                 imageVector = Icons.Filled.KeyboardArrowUp,
                 contentDescription = "minimize_button",
                 modifier =
-                Modifier
-                    .clickable { onMinimizedClick() }
-                    .testTag(TestTags.MAP_BANNER_BUTTON))
+                    Modifier.clickable { onMinimizedClick() }.testTag(TestTags.MAP_BANNER_BUTTON))
             // Itinerary Title
             Text(
                 text = itinerary.title,
@@ -489,9 +459,7 @@ private fun PreviewItineraryBannerMinimized(onMinimizedClick: () -> Unit, itiner
                 fontFamily = MaterialTheme.typography.displayLarge.fontFamily,
                 fontSize = titleFontSize,
                 fontWeight = FontWeight.Normal,
-                modifier = Modifier
-                    .padding(2.dp)
-                    .testTag(TestTags.MAP_ITINERARY_TITLE),
+                modifier = Modifier.padding(2.dp).testTag(TestTags.MAP_ITINERARY_TITLE),
                 textAlign = TextAlign.Center)
           }
         }
@@ -500,11 +468,11 @@ private fun PreviewItineraryBannerMinimized(onMinimizedClick: () -> Unit, itiner
 
 /**
  * @brief: Button which switches back and forth between centered on user and centered on itinerary
- * */
+ */
 @Composable
 fun CenterButton(center: () -> Unit) {
   FloatingActionButton(
-      onClick = {center()},
+      onClick = { center() },
       modifier = Modifier.testTag(TestTags.MAP_CENTER_CAMERA_BUTTON),
       containerColor = MaterialTheme.colorScheme.surfaceContainer) {
         Icon(
@@ -520,10 +488,9 @@ fun NullItinerary(userLocation: Location?) {
   if (userLocation == null) {
     Column(
         modifier =
-        Modifier
-            .testTag(TestTags.MAP_NULL_ITINERARY)
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
+            Modifier.testTag(TestTags.MAP_NULL_ITINERARY)
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center) {
           Text("Loading...", modifier = Modifier.testTag(TestTags.MAP_NULL_ITINERARY))
@@ -534,9 +501,7 @@ fun NullItinerary(userLocation: Location?) {
       position = CameraPosition.fromLatLngZoom(userLocationLatLng, 13f)
     }
     GoogleMap(
-        modifier = Modifier
-            .fillMaxSize()
-            .testTag(TestTags.MAP_NULL_ITINERARY),
+        modifier = Modifier.fillMaxSize().testTag(TestTags.MAP_NULL_ITINERARY),
         cameraPositionState = cameraPositionState) {
           Marker(
               tag = TestTags.MAP_USER_LOCATION,

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScopeInstance.align
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -174,7 +173,10 @@ fun PreviewItineraryScreen(
                       }
                   }
               }
-              FollowItineraryButton(followItinerary)
+              FollowItineraryButton(
+                  followItinerary,
+                  Modifier.align(Alignment.TopCenter) // this parameter allows alignment wrt containing Box composable
+              )
           }
         }
   }
@@ -184,7 +186,7 @@ fun PreviewItineraryScreen(
  * @brief: Button which launches google maps with specified itinerary once pressed
  */
 @Composable
-fun FollowItineraryButton(followItinerary: () -> Unit) {
+fun FollowItineraryButton(followItinerary: () -> Unit, modifier: Modifier) {
     ExtendedFloatingActionButton(
         onClick = { followItinerary() },
         icon = {
@@ -198,9 +200,7 @@ fun FollowItineraryButton(followItinerary: () -> Unit) {
         },
         containerColor = MaterialTheme.colorScheme.secondaryContainer,
         contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-        modifier =
-        Modifier
-            .align(Alignment.TopCenter)
+        modifier = modifier
             .padding(12.dp)
             .testTag(TestTags.START_NEW_ITINERARY_STARTING))
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScopeInstance.align
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -90,6 +91,10 @@ fun PreviewItineraryScreen(
   val itinerary = itineraryViewModel.getFocusedItinerary()
   val context = LocalContext.current
 
+  val followItinerary = {
+      itineraryViewModel.followItineraryOnGoogleMaps(context, itinerary!!)
+  }
+
   if (itinerary == null) {
     NullItinerary(userLocation)
   } else {
@@ -120,7 +125,6 @@ fun PreviewItineraryScreen(
     val polylinePoints by itineraryViewModel.getPolylinePointsLiveData().observeAsState()
     var isMinimized by remember { mutableStateOf(false) }
     val onMinimizedClick = { isMinimized = !isMinimized }
-    var isClicked by remember { mutableStateOf(false) }
 
     Scaffold(
         bottomBar = {
@@ -170,20 +174,19 @@ fun PreviewItineraryScreen(
                       }
                   }
               }
-              FollowItineraryButton()
+              FollowItineraryButton(followItinerary)
           }
         }
   }
 }
 
+/**
+ * @brief: Button which launches google maps with specified itinerary once pressed
+ */
 @Composable
-fun FollowItineraryButton() {
+fun FollowItineraryButton(followItinerary: () -> Unit) {
     ExtendedFloatingActionButton(
-        onClick = {
-            onMinimizedClick()
-            isClicked = !isClicked
-            itineraryViewModel.followItineraryOnGoogleMaps(context, itinerary)
-        },
+        onClick = { followItinerary() },
         icon = {
             Icon(
                 Icons.AutoMirrored.Filled.DirectionsWalk,
@@ -191,7 +194,7 @@ fun FollowItineraryButton() {
                 modifier = Modifier.size(32.dp))
         },
         text = {
-            Text(text = if (isClicked) "Following..." else "Follow", color = Color.DarkGray)
+            Text(text = "Follow", color = Color.DarkGray)
         },
         containerColor = MaterialTheme.colorScheme.secondaryContainer,
         contentColor = MaterialTheme.colorScheme.onSecondaryContainer,

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
@@ -467,22 +467,20 @@ fun CenterButton(
   var centeredOnUser by remember { mutableStateOf(false) }
 
   // pressing on center button changes centerOnUser variable which launches camera movement
-  userLocation?.let { location ->
-    LaunchedEffect(centeredOnUser) {
+  LaunchedEffect(centeredOnUser) {
       try {
         cameraPositionState.move(
-            if (centeredOnUser) {
-              val latLng = location.toLatLng()
+            if (centeredOnUser && userLocation != null) {
+              val latLng = userLocation.toLatLng()
               CameraUpdateFactory.newLatLngZoom(latLng, 13f)
             } else {
               CameraUpdateFactory.newLatLngZoom(
                   itinerary.computeCenterOfGravity().toLatLng(),
                   itinerary.computeOptimalZoomLevel())
             })
-      } catch (_: NullPointerException) {
+      } catch (_: NullPointerException) { // This is used when testing, the CameraUpdateFactory is null
         /* Do nothing */
       }
-    }
   }
 
   FloatingActionButton(

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
@@ -468,19 +468,19 @@ fun CenterButton(
 
   // pressing on center button changes centerOnUser variable which launches camera movement
   LaunchedEffect(centeredOnUser) {
-      try {
-        cameraPositionState.move(
-            if (centeredOnUser && userLocation != null) {
-              val latLng = userLocation.toLatLng()
-              CameraUpdateFactory.newLatLngZoom(latLng, 13f)
-            } else {
-              CameraUpdateFactory.newLatLngZoom(
-                  itinerary.computeCenterOfGravity().toLatLng(),
-                  itinerary.computeOptimalZoomLevel())
-            })
-      } catch (_: NullPointerException) { // This is used when testing, the CameraUpdateFactory is null
-        /* Do nothing */
-      }
+    try {
+      cameraPositionState.move(
+          if (centeredOnUser && userLocation != null) {
+            val latLng = userLocation.toLatLng()
+            CameraUpdateFactory.newLatLngZoom(latLng, 13f)
+          } else {
+            CameraUpdateFactory.newLatLngZoom(
+                itinerary.computeCenterOfGravity().toLatLng(), itinerary.computeOptimalZoomLevel())
+          })
+    } catch (
+        _: NullPointerException) { // This is used when testing, the CameraUpdateFactory is null
+      /* Do nothing */
+    }
   }
 
   FloatingActionButton(

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
@@ -139,56 +139,67 @@ fun PreviewItineraryScreen(
         },
         floatingActionButtonPosition = FabPosition.Start) { paddingValues ->
           Box {
-            GoogleMap(
-                modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-                    .testTag(TestTags.MAP_GOOGLE_MAPS),
-                cameraPositionState = cameraPositionState) {
+              GoogleMap(
+                  modifier =
+                  Modifier
+                      .fillMaxSize()
+                      .padding(paddingValues)
+                      .testTag(TestTags.MAP_GOOGLE_MAPS),
+                  cameraPositionState = cameraPositionState
+              ) {
                   userLocation?.let {
-                    Marker(
-                        tag = TestTags.MAP_USER_LOCATION,
-                        state = MarkerState(position = it.toLatLng()),
-                        icon =
-                            BitmapDescriptorFactory.defaultMarker(
-                                BitmapDescriptorFactory.HUE_AZURE))
+                      Marker(
+                          tag = TestTags.MAP_USER_LOCATION,
+                          state = MarkerState(position = it.toLatLng()),
+                          icon =
+                          BitmapDescriptorFactory.defaultMarker(
+                              BitmapDescriptorFactory.HUE_AZURE
+                          )
+                      )
                   }
                   itinerary.locations.map { location ->
-                    AdvancedMarker(
-                        state = MarkerState(position = location.toLatLng()),
-                        title = location.title,
-                    )
-                    if (polylinePoints != null) {
-                      Polyline(points = polylinePoints!!, color = MaterialTheme.colorScheme.primary)
-                    }
+                      AdvancedMarker(
+                          state = MarkerState(position = location.toLatLng()),
+                          title = location.title,
+                      )
+                      if (polylinePoints != null) {
+                          Polyline(
+                              points = polylinePoints!!,
+                              color = MaterialTheme.colorScheme.primary
+                          )
+                      }
                   }
-                }
-            ExtendedFloatingActionButton(
-                onClick = {
-                  onMinimizedClick()
-                  isClicked = !isClicked
-                  itineraryViewModel.followItineraryOnGoogleMaps(context, itinerary)
-                },
-                icon = {
-                  Icon(
-                      Icons.AutoMirrored.Filled.DirectionsWalk,
-                      contentDescription = "follow",
-                      modifier = Modifier.size(32.dp))
-                },
-                text = {
-                  Text(text = if (isClicked) "Following..." else "Follow", color = Color.DarkGray)
-                },
-                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                modifier =
-                Modifier
-                    .align(Alignment.TopCenter)
-                    .padding(12.dp)
-                    .testTag(TestTags.START_NEW_ITINERARY_STARTING))
+              }
+              FollowItineraryButton()
           }
         }
   }
+}
+
+@Composable
+fun FollowItineraryButton() {
+    ExtendedFloatingActionButton(
+        onClick = {
+            onMinimizedClick()
+            isClicked = !isClicked
+            itineraryViewModel.followItineraryOnGoogleMaps(context, itinerary)
+        },
+        icon = {
+            Icon(
+                Icons.AutoMirrored.Filled.DirectionsWalk,
+                contentDescription = "follow",
+                modifier = Modifier.size(32.dp))
+        },
+        text = {
+            Text(text = if (isClicked) "Following..." else "Follow", color = Color.DarkGray)
+        },
+        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        modifier =
+        Modifier
+            .align(Alignment.TopCenter)
+            .padding(12.dp)
+            .testTag(TestTags.START_NEW_ITINERARY_STARTING))
 }
 
 /**
@@ -229,7 +240,7 @@ private fun PreviewItineraryBannerMaximized(
 ) {
   val titleFontSize = 32.sp
   val innerFontSize = 16.sp
-  var ctr = remember { mutableIntStateOf(0) }
+  val ctr = remember { mutableIntStateOf(0) }
 
   val profilePictureModifier =
       Modifier

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
@@ -66,10 +66,12 @@ import com.github.wanderwise_inc.app.ui.navigation.NavigationActions
 import com.github.wanderwise_inc.app.ui.profile.ProfilePicture
 import com.github.wanderwise_inc.app.viewmodel.ItineraryViewModel
 import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
+import com.google.android.gms.maps.CameraUpdate
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.maps.android.compose.AdvancedMarker
+import com.google.maps.android.compose.CameraPositionState
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.MarkerState
@@ -94,7 +96,6 @@ fun PreviewItineraryScreen(
   if (itinerary == null) {
     NullItinerary(userLocation)
   } else {
-    var centeredOnUser by remember { mutableStateOf(false) }
     val cameraPositionState =
         rememberCameraPositionState(key = itinerary.toString()) {
           position =
@@ -102,18 +103,6 @@ fun PreviewItineraryScreen(
                   itinerary.computeCenterOfGravity().toLatLng(),
                   itinerary.computeOptimalZoomLevel())
         }
-
-    // pressing on center button changed centerOnUser variable which launches camera movement
-    LaunchedEffect(centeredOnUser) {
-      cameraPositionState.move(
-          if (centeredOnUser && userLocation != null) {
-            val latLng = userLocation!!.toLatLng()
-            CameraUpdateFactory.newLatLngZoom(latLng, 13f)
-          } else {
-            CameraUpdateFactory.newLatLngZoom(
-                itinerary.computeCenterOfGravity().toLatLng(), itinerary.computeOptimalZoomLevel())
-          })
-    }
 
     LaunchedEffect(Unit) { itineraryViewModel.fetchPolylineLocations(itinerary) }
     val polylinePoints by itineraryViewModel.getPolylinePointsLiveData().observeAsState()
@@ -132,12 +121,19 @@ fun PreviewItineraryScreen(
               navController)
         },
         modifier = Modifier.testTag(TestTags.MAP_PREVIEW_ITINERARY_SCREEN),
-        floatingActionButton = { CenterButton { centeredOnUser = !centeredOnUser } },
+        floatingActionButton = { CenterButton(
+            cameraPositionState,
+            userLocation,
+            itinerary,
+        ) },
         floatingActionButtonPosition = FabPosition.Start) { paddingValues ->
           Box {
             GoogleMap(
                 modifier =
-                    Modifier.fillMaxSize().padding(paddingValues).testTag(TestTags.MAP_GOOGLE_MAPS),
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .testTag(TestTags.MAP_GOOGLE_MAPS),
                 cameraPositionState = cameraPositionState) {
                   userLocation?.let {
                     Marker(
@@ -182,7 +178,9 @@ fun FollowItineraryButton(followItinerary: () -> Unit, modifier: Modifier) {
       text = { Text(text = "Follow", color = Color.DarkGray) },
       containerColor = MaterialTheme.colorScheme.secondaryContainer,
       contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-      modifier = modifier.padding(12.dp).testTag(TestTags.START_NEW_ITINERARY_STARTING))
+      modifier = modifier
+          .padding(12.dp)
+          .testTag(TestTags.START_NEW_ITINERARY_STARTING))
 }
 
 /**
@@ -226,7 +224,10 @@ private fun PreviewItineraryBannerMaximized(
   val ctr = remember { mutableIntStateOf(0) }
 
   val profilePictureModifier =
-      Modifier.clip(RoundedCornerShape(5.dp)).size(50.dp).testTag(TestTags.MAP_PROFILE_PIC)
+      Modifier
+          .clip(RoundedCornerShape(5.dp))
+          .size(50.dp)
+          .testTag(TestTags.MAP_PROFILE_PIC)
 
   val profile by profileViewModel.getProfile(itinerary.userUid).collectAsState(initial = null)
 
@@ -239,11 +240,12 @@ private fun PreviewItineraryBannerMaximized(
         val scrollState = rememberScrollState()
         Column(
             modifier =
-                Modifier.background(MaterialTheme.colorScheme.primaryContainer)
-                    .fillMaxWidth()
-                    .aspectRatio(1.2f)
-                    .padding(30.dp)
-                    .verticalScroll(scrollState),
+            Modifier
+                .background(MaterialTheme.colorScheme.primaryContainer)
+                .fillMaxWidth()
+                .aspectRatio(1.2f)
+                .padding(30.dp)
+                .verticalScroll(scrollState),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Top,
         ) {
@@ -253,7 +255,9 @@ private fun PreviewItineraryBannerMaximized(
                 imageVector = Icons.Filled.KeyboardArrowDown,
                 contentDescription = "minimize_button",
                 modifier =
-                    Modifier.clickable { onMinimizedClick() }.testTag(TestTags.MAP_BANNER_BUTTON))
+                Modifier
+                    .clickable { onMinimizedClick() }
+                    .testTag(TestTags.MAP_BANNER_BUTTON))
             // Itinerary Title
             Text(
                 text = itinerary.title,
@@ -261,7 +265,9 @@ private fun PreviewItineraryBannerMaximized(
                 fontFamily = MaterialTheme.typography.displayLarge.fontFamily,
                 fontSize = titleFontSize,
                 fontWeight = FontWeight.Normal,
-                modifier = Modifier.padding(2.dp).testTag(TestTags.MAP_ITINERARY_TITLE),
+                modifier = Modifier
+                    .padding(2.dp)
+                    .testTag(TestTags.MAP_ITINERARY_TITLE),
                 textAlign = TextAlign.Center)
           }
 
@@ -373,7 +379,9 @@ private fun PreviewItineraryBannerMaximized(
                   fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
                   fontSize = innerFontSize,
                   fontWeight = FontWeight.Light,
-                  modifier = Modifier.padding(2.dp).fillMaxHeight(),
+                  modifier = Modifier
+                      .padding(2.dp)
+                      .fillMaxHeight(),
                   textAlign = TextAlign.Center,
               )
             }
@@ -392,7 +400,9 @@ private fun PreviewItineraryBannerMaximized(
                 fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Normal,
-                modifier = Modifier.padding(2.dp).testTag(TestTags.MAP_ITINERARY_DESCRIPTION),
+                modifier = Modifier
+                    .padding(2.dp)
+                    .testTag(TestTags.MAP_ITINERARY_DESCRIPTION),
                 textAlign = TextAlign.Center)
           }
           Spacer(modifier = Modifier.height(20.dp))
@@ -434,10 +444,11 @@ private fun PreviewItineraryBannerMinimized(onMinimizedClick: () -> Unit, itiner
       modifier = Modifier.testTag(TestTags.MAP_MINIMIZED_BANNER)) {
         Column(
             modifier =
-                Modifier.background(MaterialTheme.colorScheme.primaryContainer)
-                    .fillMaxWidth()
-                    .aspectRatio(3f)
-                    .padding(30.dp),
+            Modifier
+                .background(MaterialTheme.colorScheme.primaryContainer)
+                .fillMaxWidth()
+                .aspectRatio(3f)
+                .padding(30.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
           Row {
@@ -446,7 +457,9 @@ private fun PreviewItineraryBannerMinimized(onMinimizedClick: () -> Unit, itiner
                 imageVector = Icons.Filled.KeyboardArrowUp,
                 contentDescription = "minimize_button",
                 modifier =
-                    Modifier.clickable { onMinimizedClick() }.testTag(TestTags.MAP_BANNER_BUTTON))
+                Modifier
+                    .clickable { onMinimizedClick() }
+                    .testTag(TestTags.MAP_BANNER_BUTTON))
             // Itinerary Title
             Text(
                 text = itinerary.title,
@@ -454,7 +467,9 @@ private fun PreviewItineraryBannerMinimized(onMinimizedClick: () -> Unit, itiner
                 fontFamily = MaterialTheme.typography.displayLarge.fontFamily,
                 fontSize = titleFontSize,
                 fontWeight = FontWeight.Normal,
-                modifier = Modifier.padding(2.dp).testTag(TestTags.MAP_ITINERARY_TITLE),
+                modifier = Modifier
+                    .padding(2.dp)
+                    .testTag(TestTags.MAP_ITINERARY_TITLE),
                 textAlign = TextAlign.Center)
           }
         }
@@ -465,9 +480,36 @@ private fun PreviewItineraryBannerMinimized(onMinimizedClick: () -> Unit, itiner
  * @brief: Button which switches back and forth between centered on user and centered on itinerary
  */
 @Composable
-fun CenterButton(center: () -> Unit) {
+fun CenterButton(
+    cameraPositionState: CameraPositionState,
+    userLocation: Location?,
+    itinerary: Itinerary
+) {
+    var centeredOnUser by remember { mutableStateOf(false) }
+
+    // pressing on center button changes centerOnUser variable which launches camera movement
+    userLocation?.let {location ->
+        LaunchedEffect(centeredOnUser) {
+            try{
+                cameraPositionState.move(
+                    if (centeredOnUser) {
+                        val latLng = location.toLatLng()
+                        CameraUpdateFactory.newLatLngZoom(latLng, 13f)
+                    } else {
+                        CameraUpdateFactory.newLatLngZoom(
+                            itinerary.computeCenterOfGravity().toLatLng(),
+                            itinerary.computeOptimalZoomLevel()
+                        )
+                    }
+                )
+            } catch (_: NullPointerException) { /* Do nothing */ }
+        }
+    }
+
   FloatingActionButton(
-      onClick = { center() },
+      onClick = {
+          centeredOnUser = !centeredOnUser
+      },
       modifier = Modifier.testTag(TestTags.MAP_CENTER_CAMERA_BUTTON),
       containerColor = MaterialTheme.colorScheme.surfaceContainer) {
         Icon(
@@ -483,9 +525,10 @@ fun NullItinerary(userLocation: Location?) {
   if (userLocation == null) {
     Column(
         modifier =
-            Modifier.testTag(TestTags.MAP_NULL_ITINERARY)
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background),
+        Modifier
+            .testTag(TestTags.MAP_NULL_ITINERARY)
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center) {
           Text("Loading...", modifier = Modifier.testTag(TestTags.MAP_NULL_ITINERARY))
@@ -496,7 +539,9 @@ fun NullItinerary(userLocation: Location?) {
       position = CameraPosition.fromLatLngZoom(userLocationLatLng, 13f)
     }
     GoogleMap(
-        modifier = Modifier.fillMaxSize().testTag(TestTags.MAP_NULL_ITINERARY),
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag(TestTags.MAP_NULL_ITINERARY),
         cameraPositionState = cameraPositionState) {
           Marker(
               tag = TestTags.MAP_USER_LOCATION,

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
@@ -66,7 +66,6 @@ import com.github.wanderwise_inc.app.ui.navigation.NavigationActions
 import com.github.wanderwise_inc.app.ui.profile.ProfilePicture
 import com.github.wanderwise_inc.app.viewmodel.ItineraryViewModel
 import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
-import com.google.android.gms.maps.CameraUpdate
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.CameraPosition
@@ -121,19 +120,18 @@ fun PreviewItineraryScreen(
               navController)
         },
         modifier = Modifier.testTag(TestTags.MAP_PREVIEW_ITINERARY_SCREEN),
-        floatingActionButton = { CenterButton(
-            cameraPositionState,
-            userLocation,
-            itinerary,
-        ) },
+        floatingActionButton = {
+          CenterButton(
+              cameraPositionState,
+              userLocation,
+              itinerary,
+          )
+        },
         floatingActionButtonPosition = FabPosition.Start) { paddingValues ->
           Box {
             GoogleMap(
                 modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-                    .testTag(TestTags.MAP_GOOGLE_MAPS),
+                    Modifier.fillMaxSize().padding(paddingValues).testTag(TestTags.MAP_GOOGLE_MAPS),
                 cameraPositionState = cameraPositionState) {
                   userLocation?.let {
                     Marker(
@@ -178,9 +176,7 @@ fun FollowItineraryButton(followItinerary: () -> Unit, modifier: Modifier) {
       text = { Text(text = "Follow", color = Color.DarkGray) },
       containerColor = MaterialTheme.colorScheme.secondaryContainer,
       contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-      modifier = modifier
-          .padding(12.dp)
-          .testTag(TestTags.START_NEW_ITINERARY_STARTING))
+      modifier = modifier.padding(12.dp).testTag(TestTags.START_NEW_ITINERARY_STARTING))
 }
 
 /**
@@ -224,10 +220,7 @@ private fun PreviewItineraryBannerMaximized(
   val ctr = remember { mutableIntStateOf(0) }
 
   val profilePictureModifier =
-      Modifier
-          .clip(RoundedCornerShape(5.dp))
-          .size(50.dp)
-          .testTag(TestTags.MAP_PROFILE_PIC)
+      Modifier.clip(RoundedCornerShape(5.dp)).size(50.dp).testTag(TestTags.MAP_PROFILE_PIC)
 
   val profile by profileViewModel.getProfile(itinerary.userUid).collectAsState(initial = null)
 
@@ -240,12 +233,11 @@ private fun PreviewItineraryBannerMaximized(
         val scrollState = rememberScrollState()
         Column(
             modifier =
-            Modifier
-                .background(MaterialTheme.colorScheme.primaryContainer)
-                .fillMaxWidth()
-                .aspectRatio(1.2f)
-                .padding(30.dp)
-                .verticalScroll(scrollState),
+                Modifier.background(MaterialTheme.colorScheme.primaryContainer)
+                    .fillMaxWidth()
+                    .aspectRatio(1.2f)
+                    .padding(30.dp)
+                    .verticalScroll(scrollState),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Top,
         ) {
@@ -255,9 +247,7 @@ private fun PreviewItineraryBannerMaximized(
                 imageVector = Icons.Filled.KeyboardArrowDown,
                 contentDescription = "minimize_button",
                 modifier =
-                Modifier
-                    .clickable { onMinimizedClick() }
-                    .testTag(TestTags.MAP_BANNER_BUTTON))
+                    Modifier.clickable { onMinimizedClick() }.testTag(TestTags.MAP_BANNER_BUTTON))
             // Itinerary Title
             Text(
                 text = itinerary.title,
@@ -265,9 +255,7 @@ private fun PreviewItineraryBannerMaximized(
                 fontFamily = MaterialTheme.typography.displayLarge.fontFamily,
                 fontSize = titleFontSize,
                 fontWeight = FontWeight.Normal,
-                modifier = Modifier
-                    .padding(2.dp)
-                    .testTag(TestTags.MAP_ITINERARY_TITLE),
+                modifier = Modifier.padding(2.dp).testTag(TestTags.MAP_ITINERARY_TITLE),
                 textAlign = TextAlign.Center)
           }
 
@@ -379,9 +367,7 @@ private fun PreviewItineraryBannerMaximized(
                   fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
                   fontSize = innerFontSize,
                   fontWeight = FontWeight.Light,
-                  modifier = Modifier
-                      .padding(2.dp)
-                      .fillMaxHeight(),
+                  modifier = Modifier.padding(2.dp).fillMaxHeight(),
                   textAlign = TextAlign.Center,
               )
             }
@@ -400,9 +386,7 @@ private fun PreviewItineraryBannerMaximized(
                 fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Normal,
-                modifier = Modifier
-                    .padding(2.dp)
-                    .testTag(TestTags.MAP_ITINERARY_DESCRIPTION),
+                modifier = Modifier.padding(2.dp).testTag(TestTags.MAP_ITINERARY_DESCRIPTION),
                 textAlign = TextAlign.Center)
           }
           Spacer(modifier = Modifier.height(20.dp))
@@ -444,11 +428,10 @@ private fun PreviewItineraryBannerMinimized(onMinimizedClick: () -> Unit, itiner
       modifier = Modifier.testTag(TestTags.MAP_MINIMIZED_BANNER)) {
         Column(
             modifier =
-            Modifier
-                .background(MaterialTheme.colorScheme.primaryContainer)
-                .fillMaxWidth()
-                .aspectRatio(3f)
-                .padding(30.dp),
+                Modifier.background(MaterialTheme.colorScheme.primaryContainer)
+                    .fillMaxWidth()
+                    .aspectRatio(3f)
+                    .padding(30.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
           Row {
@@ -457,9 +440,7 @@ private fun PreviewItineraryBannerMinimized(onMinimizedClick: () -> Unit, itiner
                 imageVector = Icons.Filled.KeyboardArrowUp,
                 contentDescription = "minimize_button",
                 modifier =
-                Modifier
-                    .clickable { onMinimizedClick() }
-                    .testTag(TestTags.MAP_BANNER_BUTTON))
+                    Modifier.clickable { onMinimizedClick() }.testTag(TestTags.MAP_BANNER_BUTTON))
             // Itinerary Title
             Text(
                 text = itinerary.title,
@@ -467,9 +448,7 @@ private fun PreviewItineraryBannerMinimized(onMinimizedClick: () -> Unit, itiner
                 fontFamily = MaterialTheme.typography.displayLarge.fontFamily,
                 fontSize = titleFontSize,
                 fontWeight = FontWeight.Normal,
-                modifier = Modifier
-                    .padding(2.dp)
-                    .testTag(TestTags.MAP_ITINERARY_TITLE),
+                modifier = Modifier.padding(2.dp).testTag(TestTags.MAP_ITINERARY_TITLE),
                 textAlign = TextAlign.Center)
           }
         }
@@ -485,31 +464,29 @@ fun CenterButton(
     userLocation: Location?,
     itinerary: Itinerary
 ) {
-    var centeredOnUser by remember { mutableStateOf(false) }
+  var centeredOnUser by remember { mutableStateOf(false) }
 
-    // pressing on center button changes centerOnUser variable which launches camera movement
-    userLocation?.let {location ->
-        LaunchedEffect(centeredOnUser) {
-            try{
-                cameraPositionState.move(
-                    if (centeredOnUser) {
-                        val latLng = location.toLatLng()
-                        CameraUpdateFactory.newLatLngZoom(latLng, 13f)
-                    } else {
-                        CameraUpdateFactory.newLatLngZoom(
-                            itinerary.computeCenterOfGravity().toLatLng(),
-                            itinerary.computeOptimalZoomLevel()
-                        )
-                    }
-                )
-            } catch (_: NullPointerException) { /* Do nothing */ }
-        }
+  // pressing on center button changes centerOnUser variable which launches camera movement
+  userLocation?.let { location ->
+    LaunchedEffect(centeredOnUser) {
+      try {
+        cameraPositionState.move(
+            if (centeredOnUser) {
+              val latLng = location.toLatLng()
+              CameraUpdateFactory.newLatLngZoom(latLng, 13f)
+            } else {
+              CameraUpdateFactory.newLatLngZoom(
+                  itinerary.computeCenterOfGravity().toLatLng(),
+                  itinerary.computeOptimalZoomLevel())
+            })
+      } catch (_: NullPointerException) {
+        /* Do nothing */
+      }
     }
+  }
 
   FloatingActionButton(
-      onClick = {
-          centeredOnUser = !centeredOnUser
-      },
+      onClick = { centeredOnUser = !centeredOnUser },
       modifier = Modifier.testTag(TestTags.MAP_CENTER_CAMERA_BUTTON),
       containerColor = MaterialTheme.colorScheme.surfaceContainer) {
         Icon(
@@ -525,10 +502,9 @@ fun NullItinerary(userLocation: Location?) {
   if (userLocation == null) {
     Column(
         modifier =
-        Modifier
-            .testTag(TestTags.MAP_NULL_ITINERARY)
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
+            Modifier.testTag(TestTags.MAP_NULL_ITINERARY)
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center) {
           Text("Loading...", modifier = Modifier.testTag(TestTags.MAP_NULL_ITINERARY))
@@ -539,9 +515,7 @@ fun NullItinerary(userLocation: Location?) {
       position = CameraPosition.fromLatLngZoom(userLocationLatLng, 13f)
     }
     GoogleMap(
-        modifier = Modifier
-            .fillMaxSize()
-            .testTag(TestTags.MAP_NULL_ITINERARY),
+        modifier = Modifier.fillMaxSize().testTag(TestTags.MAP_NULL_ITINERARY),
         cameraPositionState = cameraPositionState) {
           Marker(
               tag = TestTags.MAP_USER_LOCATION,

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
@@ -132,12 +132,7 @@ fun PreviewItineraryScreen(
               navController)
         },
         modifier = Modifier.testTag(TestTags.MAP_PREVIEW_ITINERARY_SCREEN),
-        floatingActionButton = {
-          CenterButton(
-              /*cameraPositionState = cameraPositionState, currentLocation = userLocation*/ {
-            centeredOnUser = !centeredOnUser
-          })
-        },
+        floatingActionButton = { CenterButton { centeredOnUser = !centeredOnUser } },
         floatingActionButtonPosition = FabPosition.Start) { paddingValues ->
           Box {
             GoogleMap(

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreen.kt
@@ -93,6 +93,7 @@ fun PreviewItineraryScreen(
   if (itinerary == null) {
     NullItinerary(userLocation)
   } else {
+    var centeredOnUser by remember { mutableStateOf(false) }
     val cameraPositionState =
         rememberCameraPositionState(key = itinerary.toString()) {
           position =
@@ -100,6 +101,20 @@ fun PreviewItineraryScreen(
                   itinerary.computeCenterOfGravity().toLatLng(),
                   itinerary.computeOptimalZoomLevel())
         }
+
+    // pressing on center button changed centerOnUser variable which launches camera movement
+    LaunchedEffect(centeredOnUser) {
+        cameraPositionState.move(
+            if (centeredOnUser && userLocation!= null) {
+                val latLng = userLocation!!.toLatLng()
+                CameraUpdateFactory.newLatLngZoom(latLng, 13f)
+            } else {
+                CameraUpdateFactory.newLatLngZoom(
+                    itinerary.computeCenterOfGravity().toLatLng(),
+                    itinerary.computeOptimalZoomLevel())
+            }
+        )
+    }
 
     LaunchedEffect(Unit) { itineraryViewModel.fetchPolylineLocations(itinerary) }
     val polylinePoints by itineraryViewModel.getPolylinePointsLiveData().observeAsState()
@@ -120,13 +135,16 @@ fun PreviewItineraryScreen(
         },
         modifier = Modifier.testTag(TestTags.MAP_PREVIEW_ITINERARY_SCREEN),
         floatingActionButton = {
-          CenterButton(cameraPositionState = cameraPositionState, currentLocation = userLocation)
+          CenterButton(/*cameraPositionState = cameraPositionState, currentLocation = userLocation*/ {centeredOnUser = !centeredOnUser})
         },
         floatingActionButtonPosition = FabPosition.Start) { paddingValues ->
           Box {
             GoogleMap(
                 modifier =
-                    Modifier.fillMaxSize().padding(paddingValues).testTag(TestTags.MAP_GOOGLE_MAPS),
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .testTag(TestTags.MAP_GOOGLE_MAPS),
                 cameraPositionState = cameraPositionState) {
                   userLocation?.let {
                     Marker(
@@ -139,7 +157,7 @@ fun PreviewItineraryScreen(
                   itinerary.locations.map { location ->
                     AdvancedMarker(
                         state = MarkerState(position = location.toLatLng()),
-                        title = location.title ?: "",
+                        title = location.title,
                     )
                     if (polylinePoints != null) {
                       Polyline(points = polylinePoints!!, color = MaterialTheme.colorScheme.primary)
@@ -164,9 +182,10 @@ fun PreviewItineraryScreen(
                 containerColor = MaterialTheme.colorScheme.secondaryContainer,
                 contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
                 modifier =
-                    Modifier.align(Alignment.TopCenter)
-                        .padding(12.dp)
-                        .testTag(TestTags.START_NEW_ITINERARY_STARTING))
+                Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(12.dp)
+                    .testTag(TestTags.START_NEW_ITINERARY_STARTING))
           }
         }
   }
@@ -213,7 +232,10 @@ private fun PreviewItineraryBannerMaximized(
   var ctr = remember { mutableIntStateOf(0) }
 
   val profilePictureModifier =
-      Modifier.clip(RoundedCornerShape(5.dp)).size(50.dp).testTag(TestTags.MAP_PROFILE_PIC)
+      Modifier
+          .clip(RoundedCornerShape(5.dp))
+          .size(50.dp)
+          .testTag(TestTags.MAP_PROFILE_PIC)
 
   val profile by profileViewModel.getProfile(itinerary.userUid).collectAsState(initial = null)
 
@@ -226,11 +248,12 @@ private fun PreviewItineraryBannerMaximized(
         val scrollState = rememberScrollState()
         Column(
             modifier =
-                Modifier.background(MaterialTheme.colorScheme.primaryContainer)
-                    .fillMaxWidth()
-                    .aspectRatio(1.2f)
-                    .padding(30.dp)
-                    .verticalScroll(scrollState),
+            Modifier
+                .background(MaterialTheme.colorScheme.primaryContainer)
+                .fillMaxWidth()
+                .aspectRatio(1.2f)
+                .padding(30.dp)
+                .verticalScroll(scrollState),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Top,
         ) {
@@ -240,7 +263,9 @@ private fun PreviewItineraryBannerMaximized(
                 imageVector = Icons.Filled.KeyboardArrowDown,
                 contentDescription = "minimize_button",
                 modifier =
-                    Modifier.clickable { onMinimizedClick() }.testTag(TestTags.MAP_BANNER_BUTTON))
+                Modifier
+                    .clickable { onMinimizedClick() }
+                    .testTag(TestTags.MAP_BANNER_BUTTON))
             // Itinerary Title
             Text(
                 text = itinerary.title,
@@ -248,7 +273,9 @@ private fun PreviewItineraryBannerMaximized(
                 fontFamily = MaterialTheme.typography.displayLarge.fontFamily,
                 fontSize = titleFontSize,
                 fontWeight = FontWeight.Normal,
-                modifier = Modifier.padding(2.dp).testTag(TestTags.MAP_ITINERARY_TITLE),
+                modifier = Modifier
+                    .padding(2.dp)
+                    .testTag(TestTags.MAP_ITINERARY_TITLE),
                 textAlign = TextAlign.Center)
           }
 
@@ -360,7 +387,9 @@ private fun PreviewItineraryBannerMaximized(
                   fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
                   fontSize = innerFontSize,
                   fontWeight = FontWeight.Light,
-                  modifier = Modifier.padding(2.dp).fillMaxHeight(),
+                  modifier = Modifier
+                      .padding(2.dp)
+                      .fillMaxHeight(),
                   textAlign = TextAlign.Center,
               )
             }
@@ -379,7 +408,9 @@ private fun PreviewItineraryBannerMaximized(
                 fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Normal,
-                modifier = Modifier.padding(2.dp).testTag(TestTags.MAP_ITINERARY_DESCRIPTION),
+                modifier = Modifier
+                    .padding(2.dp)
+                    .testTag(TestTags.MAP_ITINERARY_DESCRIPTION),
                 textAlign = TextAlign.Center)
           }
           Spacer(modifier = Modifier.height(20.dp))
@@ -421,10 +452,11 @@ private fun PreviewItineraryBannerMinimized(onMinimizedClick: () -> Unit, itiner
       modifier = Modifier.testTag(TestTags.MAP_MINIMIZED_BANNER)) {
         Column(
             modifier =
-                Modifier.background(MaterialTheme.colorScheme.primaryContainer)
-                    .fillMaxWidth()
-                    .aspectRatio(3f)
-                    .padding(30.dp),
+            Modifier
+                .background(MaterialTheme.colorScheme.primaryContainer)
+                .fillMaxWidth()
+                .aspectRatio(3f)
+                .padding(30.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
           Row {
@@ -433,7 +465,9 @@ private fun PreviewItineraryBannerMinimized(onMinimizedClick: () -> Unit, itiner
                 imageVector = Icons.Filled.KeyboardArrowUp,
                 contentDescription = "minimize_button",
                 modifier =
-                    Modifier.clickable { onMinimizedClick() }.testTag(TestTags.MAP_BANNER_BUTTON))
+                Modifier
+                    .clickable { onMinimizedClick() }
+                    .testTag(TestTags.MAP_BANNER_BUTTON))
             // Itinerary Title
             Text(
                 text = itinerary.title,
@@ -441,22 +475,22 @@ private fun PreviewItineraryBannerMinimized(onMinimizedClick: () -> Unit, itiner
                 fontFamily = MaterialTheme.typography.displayLarge.fontFamily,
                 fontSize = titleFontSize,
                 fontWeight = FontWeight.Normal,
-                modifier = Modifier.padding(2.dp).testTag(TestTags.MAP_ITINERARY_TITLE),
+                modifier = Modifier
+                    .padding(2.dp)
+                    .testTag(TestTags.MAP_ITINERARY_TITLE),
                 textAlign = TextAlign.Center)
           }
         }
       }
 }
 
+/**
+ * @brief: Button which switches back and forth between centered on user and centered on itinerary
+ * */
 @Composable
-fun CenterButton(cameraPositionState: CameraPositionState, currentLocation: Location?) {
+fun CenterButton(center: () -> Unit) {
   FloatingActionButton(
-      onClick = {
-        currentLocation?.let {
-          val latLng = it.toLatLng()
-          cameraPositionState.move(CameraUpdateFactory.newLatLngZoom(latLng, 13f))
-        }
-      },
+      onClick = {center()},
       modifier = Modifier.testTag(TestTags.MAP_CENTER_CAMERA_BUTTON),
       containerColor = MaterialTheme.colorScheme.surfaceContainer) {
         Icon(
@@ -472,9 +506,10 @@ fun NullItinerary(userLocation: Location?) {
   if (userLocation == null) {
     Column(
         modifier =
-            Modifier.testTag(TestTags.MAP_NULL_ITINERARY)
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background),
+        Modifier
+            .testTag(TestTags.MAP_NULL_ITINERARY)
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center) {
           Text("Loading...", modifier = Modifier.testTag(TestTags.MAP_NULL_ITINERARY))
@@ -485,7 +520,9 @@ fun NullItinerary(userLocation: Location?) {
       position = CameraPosition.fromLatLngZoom(userLocationLatLng, 13f)
     }
     GoogleMap(
-        modifier = Modifier.fillMaxSize().testTag(TestTags.MAP_NULL_ITINERARY),
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag(TestTags.MAP_NULL_ITINERARY),
         cameraPositionState = cameraPositionState) {
           Marker(
               tag = TestTags.MAP_USER_LOCATION,

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/ItineraryViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/ItineraryViewModel.kt
@@ -18,7 +18,6 @@ import com.github.wanderwise_inc.app.model.location.Location
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 private const val DEBUG_TAG: String = "ITINERARY_VIEWMODEL"

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/ItineraryViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/ItineraryViewModel.kt
@@ -49,7 +49,6 @@ open class ItineraryViewModel(
   /** @return a flow of all `Itinerary`s associated to the currently logged in user */
   fun getUserItineraries(userUid: String): Flow<List<Itinerary>> {
     val ret = itineraryRepository.getUserItineraries(userUid)
-    ret.map { Log.d("ItineraryViewModel", "UserItineraries: $it") }
     return ret
   }
 

--- a/app/src/test/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreenKtTest.kt
+++ b/app/src/test/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreenKtTest.kt
@@ -185,7 +185,7 @@ class PreviewItineraryScreenKtTest {
               CameraPosition.fromLatLngZoom(itinerary.computeCenterOfGravity().toLatLng(), 13f)
         }
         cameraPositionStateObserver = cameraPositionState
-        Scaffold(floatingActionButton = { CenterButton(cameraPositionState, epflLocation) }) {
+        Scaffold(floatingActionButton = { CenterButton({}) }) {
             paddingValues ->
           GoogleMap(
               modifier = Modifier.padding(paddingValues), cameraPositionState = cameraPositionState)

--- a/app/src/test/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreenKtTest.kt
+++ b/app/src/test/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreenKtTest.kt
@@ -1,5 +1,6 @@
 package com.github.wanderwise_inc.app.ui.map
 
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -23,6 +24,7 @@ import com.github.wanderwise_inc.app.ui.TestTags
 import com.github.wanderwise_inc.app.viewmodel.ItineraryViewModel
 import com.github.wanderwise_inc.app.viewmodel.LocationClient
 import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
+import com.google.android.gms.maps.MapsInitializer
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest

--- a/app/src/test/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreenKtTest.kt
+++ b/app/src/test/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreenKtTest.kt
@@ -1,9 +1,5 @@
 package com.github.wanderwise_inc.app.ui.map
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -27,11 +23,7 @@ import com.github.wanderwise_inc.app.ui.TestTags
 import com.github.wanderwise_inc.app.viewmodel.ItineraryViewModel
 import com.github.wanderwise_inc.app.viewmodel.LocationClient
 import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
-import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
-import com.google.maps.android.compose.CameraPositionState
-import com.google.maps.android.compose.GoogleMap
-import com.google.maps.android.compose.rememberCameraPositionState
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue

--- a/app/src/test/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreenKtTest.kt
+++ b/app/src/test/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreenKtTest.kt
@@ -171,40 +171,6 @@ class PreviewItineraryScreenKtTest {
   }
 
   @Test
-  fun `pressing center button should update camera position`() {
-    val epflLocation = Location(epflLat, epflLon)
-
-    var cameraPositionStateObserver: CameraPositionState? = null
-
-    val delta = 0.0001
-
-    composeTestRule.setContent {
-      Box {
-        val cameraPositionState = rememberCameraPositionState {
-          position =
-              CameraPosition.fromLatLngZoom(itinerary.computeCenterOfGravity().toLatLng(), 13f)
-        }
-        cameraPositionStateObserver = cameraPositionState
-        Scaffold(floatingActionButton = { CenterButton({}) }) {
-            paddingValues ->
-          GoogleMap(
-              modifier = Modifier.padding(paddingValues), cameraPositionState = cameraPositionState)
-        }
-      }
-    }
-
-    composeTestRule.onNodeWithTag(TestTags.MAP_CENTER_CAMERA_BUTTON).assertIsDisplayed()
-    // TODO test fails: java.lang.NullPointerException: CameraUpdateFactory is not initialized
-    // composeTestRule.onNodeWithTag("Center Button").performClick()
-    /*
-    cameraPositionStateObserver?.let {
-      assertEquals(it.position.target.latitude, epflLat, delta)
-      assertEquals(it.position.target.longitude, epflLon, delta)
-    }
-    */
-  }
-
-  @Test
   fun `delete itinerary button should exist when user is the owner`() {
     profileViewModel.setActiveProfile(Profile("uid"))
     composeTestRule.setContent {

--- a/app/src/test/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreenKtTest.kt
+++ b/app/src/test/java/com/github/wanderwise_inc/app/ui/map/PreviewItineraryScreenKtTest.kt
@@ -1,6 +1,5 @@
 package com.github.wanderwise_inc.app.ui.map
 
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -24,7 +23,6 @@ import com.github.wanderwise_inc.app.ui.TestTags
 import com.github.wanderwise_inc.app.viewmodel.ItineraryViewModel
 import com.github.wanderwise_inc.app.viewmodel.LocationClient
 import com.github.wanderwise_inc.app.viewmodel.ProfileViewModel
-import com.google.android.gms.maps.MapsInitializer
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest


### PR DESCRIPTION
Changed the following features:
- Center camera button: The center camera button previously only centered the camera on the user. Now it will go back and forth between the user and the itinerary, that way the user can easily switch between a local view and a global view of the itinerary. This changes was made possible with a `try {} catch () {}` block that catch the `NullPointerException` caused by the uninitialized Google map in `PreviewItineraryScreen`.
- Follow Itinerary Button: Removed all intermediate functionalities as now clicking the button opens google maps. If the user closes google maps and returns to the app, he will probably not want the `PreviewItineraryScreen` to show that he is following the itinerary. Therefore now the button will simply propose to follow as if never clicked before.
- Removed Unused coroutine causing C rated reliability of our code. The problem was a `.map { ... }` in `getUserItineraries()` in `itineraryViewModel`.
- Also removed a commented test