### PR TITLE
Rotation fix: was crashing the app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,8 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.WanderWise">
+            android:theme="@style/Theme.WanderWise"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,8 +26,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.WanderWise"
-            android:screenOrientation="portrait">
+            android:theme="@style/Theme.WanderWise">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/github/wanderwise_inc/app/di/AppModule.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/di/AppModule.kt
@@ -57,122 +57,103 @@ import kotlinx.coroutines.launch
 class AppModule(
     private val activity: MainActivity,
 ) {
-    init {
-        Log.d("ModuleProvider", "Using AppModule")
+  init {
+    Log.d("ModuleProvider", "Using AppModule")
+  }
+
+  /** The `FirebaseAuth` instance used for authentication. */
+  val firebaseAuth: FirebaseAuth by lazy { FirebaseAuth.getInstance() }
+
+  /** The `FirebaseStorage` instance used for storing images. */
+  val firebaseStorage: FirebaseStorage by lazy { FirebaseStorage.getInstance() }
+
+  /** The `FirebaseFirestore` instance used for storing data. */
+  private val firestore: FirebaseFirestore by lazy { Firebase.firestore }
+
+  /** The `DirectionsRepository` instance used for fetching directions. */
+  val directionsRepository: DirectionsRepository by lazy {
+    DirectionsRepositoryImpl(DirectionsApiServiceFactory.createDirectionsApiService())
+  }
+
+  /** The `ImageRepository` instance used for storing images. */
+  val imageRepository: ImageRepository by lazy {
+    ImageRepositoryImpl(imageLauncher, firebaseStorage.reference, null)
+  }
+
+  /** The `ActivityResultLauncher` used for launching the image picker. */
+  private val imageLauncher: ActivityResultLauncher<Intent> by lazy {
+    activity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+      if (result.resultCode == Activity.RESULT_OK) {
+        result.data?.data?.let { imageRepository.setCurrentFile(it) }
+      }
     }
+  }
 
-    /** The `FirebaseAuth` instance used for authentication. */
-    val firebaseAuth: FirebaseAuth by lazy { FirebaseAuth.getInstance() }
+  /** The `ItineraryRepository` instance used for storing itineraries. */
+  val itineraryRepository: ItineraryRepository by lazy {
+    ItineraryRepositoryImpl(
+        firestore,
+        activity.applicationContext,
+        activity.applicationContext.savedItinerariesDataStore)
+  }
 
-    /** The `FirebaseStorage` instance used for storing images. */
-    val firebaseStorage: FirebaseStorage by lazy { FirebaseStorage.getInstance() }
+  /** The `DataStore` used for storing saved itineraries. */
+  private val Context.savedItinerariesDataStore: DataStore<SavedItineraries> by
+      dataStore("saved_itineraries.pb", SavedItinerariesSerializer)
 
-    /** The `FirebaseFirestore` instance used for storing data. */
-    private val firestore: FirebaseFirestore by lazy { Firebase.firestore }
+  /** The `LocationsRepository` instance used for fetching locations. */
+  val locationsRepository: LocationsRepository by lazy {
+    LocationsRepositoryImpl(LocationsApiServiceFactory.createLocationsApiService())
+  }
 
-    /** The `DirectionsRepository` instance used for fetching directions. */
-    val directionsRepository: DirectionsRepository by lazy {
-        DirectionsRepositoryImpl(DirectionsApiServiceFactory.createDirectionsApiService())
-    }
+  /** The `ProfileRepository` instance used for fetching user profiles. */
+  val profileRepository: ProfileRepository by lazy {
+    ProfileRepositoryImpl(firestore, activity.applicationContext)
+  }
 
-    /** The `ImageRepository` instance used for storing images. */
-    val imageRepository: ImageRepository by lazy {
-        ImageRepositoryImpl(imageLauncher, firebaseStorage.reference, null)
-    }
+  /** The `BottomNavigationViewModel` instance used for managing the bottom navigation bar. */
+  val bottomNavigationViewModel: BottomNavigationViewModel by activity.viewModels()
 
-    /** The `ActivityResultLauncher` used for launching the image picker. */
-    private val imageLauncher: ActivityResultLauncher<Intent> by lazy {
-        activity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            if (result.resultCode == Activity.RESULT_OK) {
-                result.data?.data?.let { imageRepository.setCurrentFile(it) }
-            }
-        }
-    }
-
-    /** The `ItineraryRepository` instance used for storing itineraries. */
-    val itineraryRepository: ItineraryRepository by lazy {
-        ItineraryRepositoryImpl(
-            firestore,
-            activity.applicationContext,
-            activity.applicationContext.savedItinerariesDataStore
-        )
-    }
-
-    /** The `DataStore` used for storing saved itineraries. */
-    private val Context.savedItinerariesDataStore: DataStore<SavedItineraries> by
-    dataStore("saved_itineraries.pb", SavedItinerariesSerializer)
-
-    /** The `LocationsRepository` instance used for fetching locations. */
-    val locationsRepository: LocationsRepository by lazy {
-        LocationsRepositoryImpl(LocationsApiServiceFactory.createLocationsApiService())
-    }
-
-    /** The `ProfileRepository` instance used for fetching user profiles. */
-    val profileRepository: ProfileRepository by lazy {
-        ProfileRepositoryImpl(firestore, activity.applicationContext)
-    }
-
-    /** The `BottomNavigationViewModel` instance used for managing the bottom navigation bar. */
-    val bottomNavigationViewModel: BottomNavigationViewModel by activity.viewModels()
-
-    /** The `CreateItineraryViewModel` instance used for creating itineraries. */
-    val createItineraryViewModel: CreateItineraryViewModel by activity.viewModels {
+  /** The `CreateItineraryViewModel` instance used for creating itineraries. */
+  val createItineraryViewModel: CreateItineraryViewModel by
+      activity.viewModels {
         CreateItineraryViewModel.Factory(
-            itineraryRepository,
-            directionsRepository,
-            locationsRepository,
-            locationClient
-        )
-    }
+            itineraryRepository, directionsRepository, locationsRepository, locationClient)
+      }
 
-    /** The `ItineraryViewModel` instance used for managing itineraries. */
-    val itineraryViewModel: ItineraryViewModel by activity.viewModels {
+  /** The `ItineraryViewModel` instance used for managing itineraries. */
+  val itineraryViewModel: ItineraryViewModel by
+      activity.viewModels {
         ItineraryViewModel.Factory(
-            itineraryRepository,
-            directionsRepository,
-            locationsRepository,
-            locationClient
-        )
+            itineraryRepository, directionsRepository, locationsRepository, locationClient)
+      }
+
+  /** The `LocationClient` instance used for fetching user locations. */
+  private val locationClient: LocationClient by lazy {
+    UserLocationClient(
+        activity.applicationContext,
+        LocationServices.getFusedLocationProviderClient(activity.applicationContext))
+  }
+
+  /** The `LoginViewModel` instance used for managing user authentication. */
+  val loginViewModel: LoginViewModel by
+      activity.viewModels {
+        LoginViewModel.Factory(signInLauncher, activity.applicationContext.isNetworkAvailable())
+      }
+
+  /** The `SignInLauncher` instance used for launching the sign-in flow. */
+  private val signInLauncher: SignInLauncher by lazy { GoogleSignInLauncher(signInResultLauncher) }
+
+  /** The `ActivityResultLauncher` used for launching the sign-in flow. */
+  private val signInResultLauncher: ActivityResultLauncher<Intent> by lazy {
+    activity.registerForActivityResult(FirebaseAuthUIActivityResultContract()) { res ->
+      val user = if (res.resultCode == Activity.RESULT_OK) firebaseAuth.currentUser else null
+
+      activity.lifecycleScope.launch { loginViewModel.handleSignInResult(profileViewModel, user) }
     }
+  }
 
-    /** The `LocationClient` instance used for fetching user locations. */
-    private val locationClient: LocationClient by lazy {
-        UserLocationClient(
-            activity.applicationContext,
-            LocationServices.getFusedLocationProviderClient(activity.applicationContext)
-        )
-    }
-
-    /** The `LoginViewModel` instance used for managing user authentication. */
-    val loginViewModel: LoginViewModel by activity.viewModels {
-        LoginViewModel.Factory(
-            signInLauncher,
-            activity.applicationContext.isNetworkAvailable()
-        )
-    }
-
-    /** The `SignInLauncher` instance used for launching the sign-in flow. */
-    private val signInLauncher: SignInLauncher by lazy { GoogleSignInLauncher(signInResultLauncher) }
-
-    /** The `ActivityResultLauncher` used for launching the sign-in flow. */
-    private val signInResultLauncher: ActivityResultLauncher<Intent> by lazy {
-        activity.registerForActivityResult(FirebaseAuthUIActivityResultContract()) { res ->
-            val user = if (res.resultCode == Activity.RESULT_OK) firebaseAuth.currentUser else null
-
-            activity.lifecycleScope.launch {
-                loginViewModel.handleSignInResult(
-                    profileViewModel,
-                    user
-                )
-            }
-        }
-    }
-
-    /** The `ProfileViewModel` instance used for managing user profiles. */
-    val profileViewModel: ProfileViewModel by activity.viewModels {
-        ProfileViewModel.Factory(
-            profileRepository,
-            imageRepository
-        )
-    }
+  /** The `ProfileViewModel` instance used for managing user profiles. */
+  val profileViewModel: ProfileViewModel by
+      activity.viewModels { ProfileViewModel.Factory(profileRepository, imageRepository) }
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/di/AppModule.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/di/AppModule.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.util.Log
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.datastore.core.DataStore
 import androidx.datastore.dataStore
 import androidx.lifecycle.lifecycleScope
@@ -56,101 +57,122 @@ import kotlinx.coroutines.launch
 class AppModule(
     private val activity: MainActivity,
 ) {
-  init {
-    Log.d("ModuleProvider", "Using AppModule")
-  }
-
-  /** The `FirebaseAuth` instance used for authentication. */
-  val firebaseAuth: FirebaseAuth by lazy { FirebaseAuth.getInstance() }
-
-  /** The `FirebaseStorage` instance used for storing images. */
-  val firebaseStorage: FirebaseStorage by lazy { FirebaseStorage.getInstance() }
-
-  /** The `FirebaseFirestore` instance used for storing data. */
-  private val firestore: FirebaseFirestore by lazy { Firebase.firestore }
-
-  /** The `DirectionsRepository` instance used for fetching directions. */
-  val directionsRepository: DirectionsRepository by lazy {
-    DirectionsRepositoryImpl(DirectionsApiServiceFactory.createDirectionsApiService())
-  }
-
-  /** The `ImageRepository` instance used for storing images. */
-  val imageRepository: ImageRepository by lazy {
-    ImageRepositoryImpl(imageLauncher, firebaseStorage.reference, null)
-  }
-
-  /** The `ActivityResultLauncher` used for launching the image picker. */
-  private val imageLauncher: ActivityResultLauncher<Intent> by lazy {
-    activity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-      if (result.resultCode == Activity.RESULT_OK) {
-        result.data?.data?.let { imageRepository.setCurrentFile(it) }
-      }
+    init {
+        Log.d("ModuleProvider", "Using AppModule")
     }
-  }
 
-  /** The `ItineraryRepository` instance used for storing itineraries. */
-  val itineraryRepository: ItineraryRepository by lazy {
-    ItineraryRepositoryImpl(
-        firestore,
-        activity.applicationContext,
-        activity.applicationContext.savedItinerariesDataStore)
-  }
+    /** The `FirebaseAuth` instance used for authentication. */
+    val firebaseAuth: FirebaseAuth by lazy { FirebaseAuth.getInstance() }
 
-  /** The `DataStore` used for storing saved itineraries. */
-  private val Context.savedItinerariesDataStore: DataStore<SavedItineraries> by
-      dataStore("saved_itineraries.pb", SavedItinerariesSerializer)
+    /** The `FirebaseStorage` instance used for storing images. */
+    val firebaseStorage: FirebaseStorage by lazy { FirebaseStorage.getInstance() }
 
-  /** The `LocationsRepository` instance used for fetching locations. */
-  val locationsRepository: LocationsRepository by lazy {
-    LocationsRepositoryImpl(LocationsApiServiceFactory.createLocationsApiService())
-  }
+    /** The `FirebaseFirestore` instance used for storing data. */
+    private val firestore: FirebaseFirestore by lazy { Firebase.firestore }
 
-  /** The `ProfileRepository` instance used for fetching user profiles. */
-  val profileRepository: ProfileRepository by lazy {
-    ProfileRepositoryImpl(firestore, activity.applicationContext)
-  }
-
-  /** The `BottomNavigationViewModel` instance used for managing the bottom navigation bar. */
-  val bottomNavigationViewModel: BottomNavigationViewModel by lazy { BottomNavigationViewModel() }
-
-  /** The `CreateItineraryViewModel` instance used for creating itineraries. */
-  val createItineraryViewModel by lazy {
-    CreateItineraryViewModel(
-        itineraryRepository, directionsRepository, locationsRepository, locationClient)
-  }
-
-  /** The `ItineraryViewModel` instance used for managing itineraries. */
-  val itineraryViewModel: ItineraryViewModel by lazy {
-    ItineraryViewModel(
-        itineraryRepository, directionsRepository, locationsRepository, locationClient)
-  }
-
-  /** The `LocationClient` instance used for fetching user locations. */
-  private val locationClient: LocationClient by lazy {
-    UserLocationClient(
-        activity.applicationContext,
-        LocationServices.getFusedLocationProviderClient(activity.applicationContext))
-  }
-
-  /** The `LoginViewModel` instance used for managing user authentication. */
-  val loginViewModel: LoginViewModel by lazy {
-    LoginViewModel(signInLauncher, activity.applicationContext.isNetworkAvailable())
-  }
-
-  /** The `SignInLauncher` instance used for launching the sign-in flow. */
-  private val signInLauncher: SignInLauncher by lazy { GoogleSignInLauncher(signInResultLauncher) }
-
-  /** The `ActivityResultLauncher` used for launching the sign-in flow. */
-  private val signInResultLauncher: ActivityResultLauncher<Intent> by lazy {
-    activity.registerForActivityResult(FirebaseAuthUIActivityResultContract()) { res ->
-      val user = if (res.resultCode == Activity.RESULT_OK) firebaseAuth.currentUser else null
-
-      activity.lifecycleScope.launch { loginViewModel.handleSignInResult(profileViewModel, user) }
+    /** The `DirectionsRepository` instance used for fetching directions. */
+    val directionsRepository: DirectionsRepository by lazy {
+        DirectionsRepositoryImpl(DirectionsApiServiceFactory.createDirectionsApiService())
     }
-  }
 
-  /** The `ProfileViewModel` instance used for managing user profiles. */
-  val profileViewModel: ProfileViewModel by lazy {
-    ProfileViewModel(profileRepository, imageRepository)
-  }
+    /** The `ImageRepository` instance used for storing images. */
+    val imageRepository: ImageRepository by lazy {
+        ImageRepositoryImpl(imageLauncher, firebaseStorage.reference, null)
+    }
+
+    /** The `ActivityResultLauncher` used for launching the image picker. */
+    private val imageLauncher: ActivityResultLauncher<Intent> by lazy {
+        activity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                result.data?.data?.let { imageRepository.setCurrentFile(it) }
+            }
+        }
+    }
+
+    /** The `ItineraryRepository` instance used for storing itineraries. */
+    val itineraryRepository: ItineraryRepository by lazy {
+        ItineraryRepositoryImpl(
+            firestore,
+            activity.applicationContext,
+            activity.applicationContext.savedItinerariesDataStore
+        )
+    }
+
+    /** The `DataStore` used for storing saved itineraries. */
+    private val Context.savedItinerariesDataStore: DataStore<SavedItineraries> by
+    dataStore("saved_itineraries.pb", SavedItinerariesSerializer)
+
+    /** The `LocationsRepository` instance used for fetching locations. */
+    val locationsRepository: LocationsRepository by lazy {
+        LocationsRepositoryImpl(LocationsApiServiceFactory.createLocationsApiService())
+    }
+
+    /** The `ProfileRepository` instance used for fetching user profiles. */
+    val profileRepository: ProfileRepository by lazy {
+        ProfileRepositoryImpl(firestore, activity.applicationContext)
+    }
+
+    /** The `BottomNavigationViewModel` instance used for managing the bottom navigation bar. */
+    val bottomNavigationViewModel: BottomNavigationViewModel by activity.viewModels()
+
+    /** The `CreateItineraryViewModel` instance used for creating itineraries. */
+    val createItineraryViewModel: CreateItineraryViewModel by activity.viewModels {
+        CreateItineraryViewModel.Factory(
+            itineraryRepository,
+            directionsRepository,
+            locationsRepository,
+            locationClient
+        )
+    }
+
+    /** The `ItineraryViewModel` instance used for managing itineraries. */
+    val itineraryViewModel: ItineraryViewModel by activity.viewModels {
+        ItineraryViewModel.Factory(
+            itineraryRepository,
+            directionsRepository,
+            locationsRepository,
+            locationClient
+        )
+    }
+
+    /** The `LocationClient` instance used for fetching user locations. */
+    private val locationClient: LocationClient by lazy {
+        UserLocationClient(
+            activity.applicationContext,
+            LocationServices.getFusedLocationProviderClient(activity.applicationContext)
+        )
+    }
+
+    /** The `LoginViewModel` instance used for managing user authentication. */
+    val loginViewModel: LoginViewModel by activity.viewModels {
+        LoginViewModel.Factory(
+            signInLauncher,
+            activity.applicationContext.isNetworkAvailable()
+        )
+    }
+
+    /** The `SignInLauncher` instance used for launching the sign-in flow. */
+    private val signInLauncher: SignInLauncher by lazy { GoogleSignInLauncher(signInResultLauncher) }
+
+    /** The `ActivityResultLauncher` used for launching the sign-in flow. */
+    private val signInResultLauncher: ActivityResultLauncher<Intent> by lazy {
+        activity.registerForActivityResult(FirebaseAuthUIActivityResultContract()) { res ->
+            val user = if (res.resultCode == Activity.RESULT_OK) firebaseAuth.currentUser else null
+
+            activity.lifecycleScope.launch {
+                loginViewModel.handleSignInResult(
+                    profileViewModel,
+                    user
+                )
+            }
+        }
+    }
+
+    /** The `ProfileViewModel` instance used for managing user profiles. */
+    val profileViewModel: ProfileViewModel by activity.viewModels {
+        ProfileViewModel.Factory(
+            profileRepository,
+            imageRepository
+        )
+    }
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/ui/signin/LoginScreen.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/ui/signin/LoginScreen.kt
@@ -132,8 +132,6 @@ fun LoginScreen(
 
 @Composable
 fun SignInButton(loginViewModel: LoginViewModel) {
-  var signInState = loginViewModel.signInState.observeAsState()
-
   Button(
       onClick = { loginViewModel.signIn() },
       shape = RoundedCornerShape(16.dp),

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/BottomNavigationViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/BottomNavigationViewModel.kt
@@ -2,41 +2,42 @@ package com.github.wanderwise_inc.app.viewmodel
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
 
 /** Enum representing the items in the bottom navigation bar. */
 enum class NavigationItem {
-  OVERVIEW,
-  LIKED,
-  CREATE,
-  MAP,
-  PROFILE
+    OVERVIEW,
+    LIKED,
+    CREATE,
+    MAP,
+    PROFILE
 }
 
 /** ViewModel for managing the state of the bottom navigation bar. */
-class BottomNavigationViewModel {
-  /** LiveData for the selected navigation item index. */
-  private val _selected = MutableLiveData<Int>()
+class BottomNavigationViewModel: ViewModel() {
+    /** LiveData for the selected navigation item index. */
+    private val _selected = MutableLiveData<Int>()
 
-  /**
-   * Publicly exposed LiveData for the selected navigation item index.
-   *
-   * @return the LiveData containing the index of the selected navigation item.
-   */
-  public val selected: LiveData<Int>
-    get() = _selected
+    /**
+     * Publicly exposed LiveData for the selected navigation item index.
+     *
+     * @return the LiveData containing the index of the selected navigation item.
+     */
+    val selected: LiveData<Int>
+        get() = _selected
 
-  /** Initializes the ViewModel with a default selected navigation item index. */
-  init {
-    _selected.value = 0
-    // Initialize with default value
-  }
+    /** Initializes the ViewModel with a default selected navigation item index. */
+    init {
+        _selected.value = 0
+        // Initialize with default value
+    }
 
-  /**
-   * Sets the selected navigation item index.
-   *
-   * @param index the index of the navigation item to select.
-   */
-  fun setSelected(index: Int) {
-    _selected.value = index
-  }
+    /**
+     * Sets the selected navigation item index.
+     *
+     * @param index the index of the navigation item to select.
+     */
+    fun setSelected(index: Int) {
+        _selected.value = index
+    }
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/BottomNavigationViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/BottomNavigationViewModel.kt
@@ -6,38 +6,38 @@ import androidx.lifecycle.ViewModel
 
 /** Enum representing the items in the bottom navigation bar. */
 enum class NavigationItem {
-    OVERVIEW,
-    LIKED,
-    CREATE,
-    MAP,
-    PROFILE
+  OVERVIEW,
+  LIKED,
+  CREATE,
+  MAP,
+  PROFILE
 }
 
 /** ViewModel for managing the state of the bottom navigation bar. */
-class BottomNavigationViewModel: ViewModel() {
-    /** LiveData for the selected navigation item index. */
-    private val _selected = MutableLiveData<Int>()
+class BottomNavigationViewModel : ViewModel() {
+  /** LiveData for the selected navigation item index. */
+  private val _selected = MutableLiveData<Int>()
 
-    /**
-     * Publicly exposed LiveData for the selected navigation item index.
-     *
-     * @return the LiveData containing the index of the selected navigation item.
-     */
-    val selected: LiveData<Int>
-        get() = _selected
+  /**
+   * Publicly exposed LiveData for the selected navigation item index.
+   *
+   * @return the LiveData containing the index of the selected navigation item.
+   */
+  val selected: LiveData<Int>
+    get() = _selected
 
-    /** Initializes the ViewModel with a default selected navigation item index. */
-    init {
-        _selected.value = 0
-        // Initialize with default value
-    }
+  /** Initializes the ViewModel with a default selected navigation item index. */
+  init {
+    _selected.value = 0
+    // Initialize with default value
+  }
 
-    /**
-     * Sets the selected navigation item index.
-     *
-     * @param index the index of the navigation item to select.
-     */
-    fun setSelected(index: Int) {
-        _selected.value = index
-    }
+  /**
+   * Sets the selected navigation item index.
+   *
+   * @param index the index of the navigation item to select.
+   */
+  fun setSelected(index: Int) {
+    _selected.value = index
+  }
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/CreateItineraryViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/CreateItineraryViewModel.kt
@@ -29,234 +29,223 @@ class CreateItineraryViewModel(
     locationClient: LocationClient
 ) :
     ItineraryViewModel(
-        itineraryRepository, directionsRepository, locationsRepository, locationClient
-    ) {
+        itineraryRepository, directionsRepository, locationsRepository, locationClient) {
 
-    /** Builder for the new itinerary that the signed-in user is currently building. */
-    private var newItineraryBuilder: Itinerary.Builder? = null
+  /** Builder for the new itinerary that the signed-in user is currently building. */
+  private var newItineraryBuilder: Itinerary.Builder? = null
 
-    /** Flag indicating if the itinerary is being created manually. */
-    var createItineraryManually: Boolean = false
+  /** Flag indicating if the itinerary is being created manually. */
+  var createItineraryManually: Boolean = false
 
-    /** Flag indicating if the itinerary is being created by tracking the user's location. */
-    var createItineraryByTracking: Boolean = false
+  /** Flag indicating if the itinerary is being created by tracking the user's location. */
+  var createItineraryByTracking: Boolean = false
 
-    /**
-     * Gets the maximum length allowed for the itinerary title.
-     *
-     * @return the maximum length for the title.
-     */
-    fun getMaxTitleLength(): Int {
-        return TITLE_MAX_LENGTH
+  /**
+   * Gets the maximum length allowed for the itinerary title.
+   *
+   * @return the maximum length for the title.
+   */
+  fun getMaxTitleLength(): Int {
+    return TITLE_MAX_LENGTH
+  }
+
+  /**
+   * Gets the itinerary currently being built by the user.
+   *
+   * @return the itinerary builder or `null` if not set.
+   *
+   * **USAGE EXAMPLE**
+   *
+   * ```
+   * val newItineraryBuilder = mapViewModel.getNewItinerary()!!
+   * // any attributes that should cause a recomposition should be remembered
+   * var title by remember {
+   *  mutableStateOf(newItinerary.title)
+   * }
+   * Button (
+   *  onClick = {
+   *    title = newTitle                        // update mutableState for recomposition
+   *    newItineraryBuilder.addTitle(newTitle)  // update shared state across screens
+   *  }
+   * )
+   * ```
+   */
+  fun getNewItinerary(): Itinerary.Builder? {
+    return newItineraryBuilder
+  }
+
+  /**
+   * Gets the current user ID from the itinerary builder.
+   *
+   * @return the user ID.
+   * @throws InvalidObjectException if the itinerary builder is `null`.
+   */
+  fun getCurrentUid(): String {
+    if (newItineraryBuilder == null) {
+      throw InvalidObjectException("Itinerary.Builder is `null`")
     }
+    return newItineraryBuilder!!.uid!!
+  }
 
-    /**
-     * Gets the itinerary currently being built by the user.
-     *
-     * @return the itinerary builder or `null` if not set.
-     *
-     * **USAGE EXAMPLE**
-     *
-     * ```
-     * val newItineraryBuilder = mapViewModel.getNewItinerary()!!
-     * // any attributes that should cause a recomposition should be remembered
-     * var title by remember {
-     *  mutableStateOf(newItinerary.title)
-     * }
-     * Button (
-     *  onClick = {
-     *    title = newTitle                        // update mutableState for recomposition
-     *    newItineraryBuilder.addTitle(newTitle)  // update shared state across screens
-     *  }
-     * )
-     * ```
-     */
-    fun getNewItinerary(): Itinerary.Builder? {
-        return newItineraryBuilder
+  /**
+   * Initializes a new itinerary builder.
+   *
+   * @param userUid the user ID for the new itinerary.
+   */
+  fun startNewItinerary(userUid: String) {
+    val newUid = getNewId()
+    newItineraryBuilder = Itinerary.Builder(userUid = userUid, uid = newUid)
+    Log.d(
+        "CreateItineraryViewModel", "new itinerary created with uid: ${newItineraryBuilder!!.uid}")
+  }
+
+  /** Uploads the new itinerary and clears the builder. */
+  fun finishItinerary() {
+    try {
+      uploadNewItinerary()
+    } catch (e: InvalidObjectException) {
+      Log.d("CreateItineraryViewModel", "cannot complete a null itinerary. $e")
     }
+    newItineraryBuilder = null
+  }
 
-    /**
-     * Gets the current user ID from the itinerary builder.
-     *
-     * @return the user ID.
-     * @throws InvalidObjectException if the itinerary builder is `null`.
-     */
-    fun getCurrentUid(): String {
-        if (newItineraryBuilder == null) {
-            throw InvalidObjectException("Itinerary.Builder is `null`")
+  /**
+   * Uploads the new itinerary to the repository.
+   *
+   * @throws InvalidObjectException if the itinerary builder is `null`.
+   */
+  fun uploadNewItinerary() {
+    if (newItineraryBuilder != null) itineraryRepository.setItinerary(newItineraryBuilder!!.build())
+    else throw InvalidObjectException("Itinerary.Builder is `null`")
+  }
+
+  /**
+   * Sets the title for the new itinerary.
+   *
+   * @param title the title to set.
+   */
+  fun setNewItineraryTitle(title: String) {
+    newItineraryBuilder?.title = title
+  }
+
+  /**
+   * Sets the description for the new itinerary.
+   *
+   * @param description the description to set.
+   */
+  fun setNewItineraryDescription(description: String) {
+    newItineraryBuilder?.description = description
+  }
+
+  /**
+   * Checks if the title is valid.
+   *
+   * @param title the title to check.
+   * @return `true` if the title is valid, `false` otherwise.
+   */
+  fun validTitle(title: String): Boolean {
+    return title.length < TITLE_MAX_LENGTH
+  }
+
+  /**
+   * Gets the message to display when the title is invalid.
+   *
+   * @return the invalid title message.
+   */
+  fun invalidTitleMessage(): String {
+    return "title field must be shorter than ${TITLE_MAX_LENGTH} characters"
+  }
+
+  /** Job for tracking user location. */
+  var locationJob: Job? = null
+
+  /** Coroutine scope for managing coroutines. */
+  val coroutineScope = CoroutineScope(Dispatchers.Main)
+
+  /**
+   * Starts tracking the user's location and adds it to the itinerary at the specified interval.
+   *
+   * @param intervalMillis the interval in milliseconds to add locations.
+   * @param addLiveLocation a callback function to handle live location updates.
+   */
+  fun startLocationTracking(intervalMillis: Long, addLiveLocation: (Location) -> Unit) {
+    locationJob?.cancel() // cancel some previous job
+    locationJob =
+        coroutineScope.launch {
+          locationClient.getLocationUpdates(intervalMillis).collect { location ->
+            newItineraryBuilder?.addLocation(location)
+            addLiveLocation(location)
+            Log.d("CreateItineraryViewModel", "build = $newItineraryBuilder")
+            Log.d("CreateItineraryViewModel", "locations = ${newItineraryBuilder?.locations}")
+          }
         }
-        return newItineraryBuilder!!.uid!!
+  }
+
+  /** Stops the job tasked with tracking the location. */
+  fun stopLocationTracking() {
+    locationJob?.cancel()
+  }
+
+  /** Cleans up resources when the ViewModel is cleared. */
+  public override fun onCleared() {
+    super.onCleared()
+    coroutineScope.cancel()
+  }
+
+  /**
+   * Gets a list of itinerary fields that have not been set.
+   *
+   * @return a list of ItineraryLabels for the fields that have not been set.
+   * @throws InvalidObjectException if the itinerary builder is `null`.
+   */
+  fun notSetValues(): List<String> {
+    // look if all values have been set
+    val notSetValues: MutableList<String> = mutableListOf()
+
+    if (newItineraryBuilder == null) {
+      // this case shouldn't be possible
+      // add error message
+      throw InvalidObjectException("Itinerary.Builder is `null`")
+    } else {
+      if (newItineraryBuilder!!.price == null) {
+        notSetValues.add(ItineraryLabels.PRICE)
+      }
+      if (newItineraryBuilder!!.time == null) {
+        notSetValues.add(ItineraryLabels.TIME)
+      }
+      if (newItineraryBuilder!!.description == null) {
+        notSetValues.add(ItineraryLabels.DESCRIPTION)
+      }
+      if (newItineraryBuilder!!.title == null) {
+        notSetValues.add(ItineraryLabels.TITLE)
+      }
+      if (newItineraryBuilder!!.locations.isEmpty()) {
+        notSetValues.add(ItineraryLabels.LOCATIONS)
+      }
+      if (newItineraryBuilder!!.tags.isEmpty()) {
+        notSetValues.add(ItineraryLabels.TAGS)
+      }
     }
 
-    /**
-     * Initializes a new itinerary builder.
-     *
-     * @param userUid the user ID for the new itinerary.
-     */
-    fun startNewItinerary(userUid: String) {
-        val newUid = getNewId()
-        newItineraryBuilder = Itinerary.Builder(userUid = userUid, uid = newUid)
-        Log.d(
-            "CreateItineraryViewModel",
-            "new itinerary created with uid: ${newItineraryBuilder!!.uid}"
-        )
+    // return the notSetValues (empty if everything has been set)
+    return notSetValues
+  }
+
+  /** Factory for creating a `CreateItineraryViewModel`. */
+  class Factory(
+      private val itineraryRepository: ItineraryRepository,
+      private val directionsRepository: DirectionsRepository,
+      private val locationsRepository: LocationsRepository,
+      private val locationClient: LocationClient,
+  ) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      if (modelClass.isAssignableFrom(CreateItineraryViewModel::class.java)) {
+        @Suppress("UNCHECKED_CAST")
+        return CreateItineraryViewModel(
+            itineraryRepository, directionsRepository, locationsRepository, locationClient)
+            as T
+      }
+      throw IllegalArgumentException("Unknown ViewModel class")
     }
-
-    /** Uploads the new itinerary and clears the builder. */
-    fun finishItinerary() {
-        try {
-            uploadNewItinerary()
-        } catch (e: InvalidObjectException) {
-            Log.d("CreateItineraryViewModel", "cannot complete a null itinerary. $e")
-        }
-        newItineraryBuilder = null
-    }
-
-    /**
-     * Uploads the new itinerary to the repository.
-     *
-     * @throws InvalidObjectException if the itinerary builder is `null`.
-     */
-    fun uploadNewItinerary() {
-        if (newItineraryBuilder != null) itineraryRepository.setItinerary(newItineraryBuilder!!.build())
-        else throw InvalidObjectException("Itinerary.Builder is `null`")
-    }
-
-    /**
-     * Sets the title for the new itinerary.
-     *
-     * @param title the title to set.
-     */
-    fun setNewItineraryTitle(title: String) {
-        newItineraryBuilder?.title = title
-    }
-
-    /**
-     * Sets the description for the new itinerary.
-     *
-     * @param description the description to set.
-     */
-    fun setNewItineraryDescription(description: String) {
-        newItineraryBuilder?.description = description
-    }
-
-    /**
-     * Checks if the title is valid.
-     *
-     * @param title the title to check.
-     * @return `true` if the title is valid, `false` otherwise.
-     */
-    fun validTitle(title: String): Boolean {
-        return title.length < TITLE_MAX_LENGTH
-    }
-
-    /**
-     * Gets the message to display when the title is invalid.
-     *
-     * @return the invalid title message.
-     */
-    fun invalidTitleMessage(): String {
-        return "title field must be shorter than ${TITLE_MAX_LENGTH} characters"
-    }
-
-    /** Job for tracking user location. */
-    var locationJob: Job? = null
-
-    /** Coroutine scope for managing coroutines. */
-    val coroutineScope = CoroutineScope(Dispatchers.Main)
-
-    /**
-     * Starts tracking the user's location and adds it to the itinerary at the specified interval.
-     *
-     * @param intervalMillis the interval in milliseconds to add locations.
-     * @param addLiveLocation a callback function to handle live location updates.
-     */
-    fun startLocationTracking(intervalMillis: Long, addLiveLocation: (Location) -> Unit) {
-        locationJob?.cancel() // cancel some previous job
-        locationJob =
-            coroutineScope.launch {
-                locationClient.getLocationUpdates(intervalMillis).collect { location ->
-                    newItineraryBuilder?.addLocation(location)
-                    addLiveLocation(location)
-                    Log.d("CreateItineraryViewModel", "build = $newItineraryBuilder")
-                    Log.d(
-                        "CreateItineraryViewModel",
-                        "locations = ${newItineraryBuilder?.locations}"
-                    )
-                }
-            }
-    }
-
-    /** Stops the job tasked with tracking the location. */
-    fun stopLocationTracking() {
-        locationJob?.cancel()
-    }
-
-    /** Cleans up resources when the ViewModel is cleared. */
-    public override fun onCleared() {
-        super.onCleared()
-        coroutineScope.cancel()
-    }
-
-    /**
-     * Gets a list of itinerary fields that have not been set.
-     *
-     * @return a list of ItineraryLabels for the fields that have not been set.
-     * @throws InvalidObjectException if the itinerary builder is `null`.
-     */
-    fun notSetValues(): List<String> {
-        // look if all values have been set
-        val notSetValues: MutableList<String> = mutableListOf()
-
-        if (newItineraryBuilder == null) {
-            // this case shouldn't be possible
-            // add error message
-            throw InvalidObjectException("Itinerary.Builder is `null`")
-        } else {
-            if (newItineraryBuilder!!.price == null) {
-                notSetValues.add(ItineraryLabels.PRICE)
-            }
-            if (newItineraryBuilder!!.time == null) {
-                notSetValues.add(ItineraryLabels.TIME)
-            }
-            if (newItineraryBuilder!!.description == null) {
-                notSetValues.add(ItineraryLabels.DESCRIPTION)
-            }
-            if (newItineraryBuilder!!.title == null) {
-                notSetValues.add(ItineraryLabels.TITLE)
-            }
-            if (newItineraryBuilder!!.locations.isEmpty()) {
-                notSetValues.add(ItineraryLabels.LOCATIONS)
-            }
-            if (newItineraryBuilder!!.tags.isEmpty()) {
-                notSetValues.add(ItineraryLabels.TAGS)
-            }
-        }
-
-        // return the notSetValues (empty if everything has been set)
-        return notSetValues
-    }
-
-    /**
-     * Factory for creating a `CreateItineraryViewModel`.
-     */
-    class Factory(
-        private val itineraryRepository: ItineraryRepository,
-        private val directionsRepository: DirectionsRepository,
-        private val locationsRepository: LocationsRepository,
-        private val locationClient: LocationClient,
-    ) : ViewModelProvider.Factory {
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            if (modelClass.isAssignableFrom(CreateItineraryViewModel::class.java)) {
-                @Suppress("UNCHECKED_CAST")
-                return CreateItineraryViewModel(
-                    itineraryRepository,
-                    directionsRepository,
-                    locationsRepository,
-                    locationClient
-                ) as T
-            }
-            throw IllegalArgumentException("Unknown ViewModel class")
-        }
-    }
+  }
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/CreateItineraryViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/CreateItineraryViewModel.kt
@@ -1,6 +1,8 @@
 package com.github.wanderwise_inc.app.viewmodel
 
 import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import com.github.wanderwise_inc.app.data.DirectionsRepository
 import com.github.wanderwise_inc.app.data.ItineraryRepository
 import com.github.wanderwise_inc.app.data.LocationsRepository
@@ -27,205 +29,234 @@ class CreateItineraryViewModel(
     locationClient: LocationClient
 ) :
     ItineraryViewModel(
-        itineraryRepository, directionsRepository, locationsRepository, locationClient) {
+        itineraryRepository, directionsRepository, locationsRepository, locationClient
+    ) {
 
-  /** Builder for the new itinerary that the signed-in user is currently building. */
-  private var newItineraryBuilder: Itinerary.Builder? = null
+    /** Builder for the new itinerary that the signed-in user is currently building. */
+    private var newItineraryBuilder: Itinerary.Builder? = null
 
-  /** Flag indicating if the itinerary is being created manually. */
-  var createItineraryManually: Boolean = false
+    /** Flag indicating if the itinerary is being created manually. */
+    var createItineraryManually: Boolean = false
 
-  /** Flag indicating if the itinerary is being created by tracking the user's location. */
-  var createItineraryByTracking: Boolean = false
+    /** Flag indicating if the itinerary is being created by tracking the user's location. */
+    var createItineraryByTracking: Boolean = false
 
-  /**
-   * Gets the maximum length allowed for the itinerary title.
-   *
-   * @return the maximum length for the title.
-   */
-  fun getMaxTitleLength(): Int {
-    return TITLE_MAX_LENGTH
-  }
-
-  /**
-   * Gets the itinerary currently being built by the user.
-   *
-   * @return the itinerary builder or `null` if not set.
-   *
-   * **USAGE EXAMPLE**
-   *
-   * ```
-   * val newItineraryBuilder = mapViewModel.getNewItinerary()!!
-   * // any attributes that should cause a recomposition should be remembered
-   * var title by remember {
-   *  mutableStateOf(newItinerary.title)
-   * }
-   * Button (
-   *  onClick = {
-   *    title = newTitle                        // update mutableState for recomposition
-   *    newItineraryBuilder.addTitle(newTitle)  // update shared state across screens
-   *  }
-   * )
-   * ```
-   */
-  fun getNewItinerary(): Itinerary.Builder? {
-    return newItineraryBuilder
-  }
-
-  /**
-   * Gets the current user ID from the itinerary builder.
-   *
-   * @return the user ID.
-   * @throws InvalidObjectException if the itinerary builder is `null`.
-   */
-  fun getCurrentUid(): String {
-    if (newItineraryBuilder == null) {
-      throw InvalidObjectException("Itinerary.Builder is `null`")
+    /**
+     * Gets the maximum length allowed for the itinerary title.
+     *
+     * @return the maximum length for the title.
+     */
+    fun getMaxTitleLength(): Int {
+        return TITLE_MAX_LENGTH
     }
-    return newItineraryBuilder!!.uid!!
-  }
 
-  /**
-   * Initializes a new itinerary builder.
-   *
-   * @param userUid the user ID for the new itinerary.
-   */
-  fun startNewItinerary(userUid: String) {
-    val newUid = getNewId()
-    newItineraryBuilder = Itinerary.Builder(userUid = userUid, uid = newUid)
-    Log.d(
-        "CreateItineraryViewModel", "new itinerary created with uid: ${newItineraryBuilder!!.uid}")
-  }
-
-  /** Uploads the new itinerary and clears the builder. */
-  fun finishItinerary() {
-    try {
-      uploadNewItinerary()
-    } catch (e: InvalidObjectException) {
-      Log.d("CreateItineraryViewModel", "cannot complete a null itinerary. $e")
+    /**
+     * Gets the itinerary currently being built by the user.
+     *
+     * @return the itinerary builder or `null` if not set.
+     *
+     * **USAGE EXAMPLE**
+     *
+     * ```
+     * val newItineraryBuilder = mapViewModel.getNewItinerary()!!
+     * // any attributes that should cause a recomposition should be remembered
+     * var title by remember {
+     *  mutableStateOf(newItinerary.title)
+     * }
+     * Button (
+     *  onClick = {
+     *    title = newTitle                        // update mutableState for recomposition
+     *    newItineraryBuilder.addTitle(newTitle)  // update shared state across screens
+     *  }
+     * )
+     * ```
+     */
+    fun getNewItinerary(): Itinerary.Builder? {
+        return newItineraryBuilder
     }
-    newItineraryBuilder = null
-  }
 
-  /**
-   * Uploads the new itinerary to the repository.
-   *
-   * @throws InvalidObjectException if the itinerary builder is `null`.
-   */
-  fun uploadNewItinerary() {
-    if (newItineraryBuilder != null) itineraryRepository.setItinerary(newItineraryBuilder!!.build())
-    else throw InvalidObjectException("Itinerary.Builder is `null`")
-  }
-
-  /**
-   * Sets the title for the new itinerary.
-   *
-   * @param title the title to set.
-   */
-  fun setNewItineraryTitle(title: String) {
-    newItineraryBuilder?.title = title
-  }
-
-  /**
-   * Sets the description for the new itinerary.
-   *
-   * @param description the description to set.
-   */
-  fun setNewItineraryDescription(description: String) {
-    newItineraryBuilder?.description = description
-  }
-
-  /**
-   * Checks if the title is valid.
-   *
-   * @param title the title to check.
-   * @return `true` if the title is valid, `false` otherwise.
-   */
-  fun validTitle(title: String): Boolean {
-    return title.length < TITLE_MAX_LENGTH
-  }
-
-  /**
-   * Gets the message to display when the title is invalid.
-   *
-   * @return the invalid title message.
-   */
-  fun invalidTitleMessage(): String {
-    return "title field must be shorter than ${TITLE_MAX_LENGTH} characters"
-  }
-
-  /** Job for tracking user location. */
-  var locationJob: Job? = null
-
-  /** Coroutine scope for managing coroutines. */
-  val coroutineScope = CoroutineScope(Dispatchers.Main)
-
-  /**
-   * Starts tracking the user's location and adds it to the itinerary at the specified interval.
-   *
-   * @param intervalMillis the interval in milliseconds to add locations.
-   * @param addLiveLocation a callback function to handle live location updates.
-   */
-  fun startLocationTracking(intervalMillis: Long, addLiveLocation: (Location) -> Unit) {
-    locationJob?.cancel() // cancel some previous job
-    locationJob =
-        coroutineScope.launch {
-          locationClient.getLocationUpdates(intervalMillis).collect { location ->
-            newItineraryBuilder?.addLocation(location)
-            addLiveLocation(location)
-            Log.d("CreateItineraryViewModel", "build = $newItineraryBuilder")
-            Log.d("CreateItineraryViewModel", "locations = ${newItineraryBuilder?.locations}")
-          }
+    /**
+     * Gets the current user ID from the itinerary builder.
+     *
+     * @return the user ID.
+     * @throws InvalidObjectException if the itinerary builder is `null`.
+     */
+    fun getCurrentUid(): String {
+        if (newItineraryBuilder == null) {
+            throw InvalidObjectException("Itinerary.Builder is `null`")
         }
-  }
-
-  /** Stops the job tasked with tracking the location. */
-  fun stopLocationTracking() {
-    locationJob?.cancel()
-  }
-
-  /** Cleans up resources when the ViewModel is cleared. */
-  public override fun onCleared() {
-    super.onCleared()
-    coroutineScope.cancel()
-  }
-
-  /**
-   * Gets a list of itinerary fields that have not been set.
-   *
-   * @return a list of ItineraryLabels for the fields that have not been set.
-   * @throws InvalidObjectException if the itinerary builder is `null`.
-   */
-  fun notSetValues(): List<String> {
-    // look if all values have been set
-    val notSetValues: MutableList<String> = mutableListOf()
-
-    if (newItineraryBuilder == null) {
-      // this case shouldn't be possible
-      // add error message
-      throw InvalidObjectException("Itinerary.Builder is `null`")
-    } else {
-      if (newItineraryBuilder!!.price == null) {
-        notSetValues.add(ItineraryLabels.PRICE)
-      }
-      if (newItineraryBuilder!!.time == null) {
-        notSetValues.add(ItineraryLabels.TIME)
-      }
-      if (newItineraryBuilder!!.description == null) {
-        notSetValues.add(ItineraryLabels.DESCRIPTION)
-      }
-      if (newItineraryBuilder!!.title == null) {
-        notSetValues.add(ItineraryLabels.TITLE)
-      }
-      if (newItineraryBuilder!!.locations.isEmpty()) {
-        notSetValues.add(ItineraryLabels.LOCATIONS)
-      }
-      if (newItineraryBuilder!!.tags.isEmpty()) {
-        notSetValues.add(ItineraryLabels.TAGS)
-      }
+        return newItineraryBuilder!!.uid!!
     }
 
-    // return the notSetValues (empty if everything has been set)
-    return notSetValues
-  }
+    /**
+     * Initializes a new itinerary builder.
+     *
+     * @param userUid the user ID for the new itinerary.
+     */
+    fun startNewItinerary(userUid: String) {
+        val newUid = getNewId()
+        newItineraryBuilder = Itinerary.Builder(userUid = userUid, uid = newUid)
+        Log.d(
+            "CreateItineraryViewModel",
+            "new itinerary created with uid: ${newItineraryBuilder!!.uid}"
+        )
+    }
+
+    /** Uploads the new itinerary and clears the builder. */
+    fun finishItinerary() {
+        try {
+            uploadNewItinerary()
+        } catch (e: InvalidObjectException) {
+            Log.d("CreateItineraryViewModel", "cannot complete a null itinerary. $e")
+        }
+        newItineraryBuilder = null
+    }
+
+    /**
+     * Uploads the new itinerary to the repository.
+     *
+     * @throws InvalidObjectException if the itinerary builder is `null`.
+     */
+    fun uploadNewItinerary() {
+        if (newItineraryBuilder != null) itineraryRepository.setItinerary(newItineraryBuilder!!.build())
+        else throw InvalidObjectException("Itinerary.Builder is `null`")
+    }
+
+    /**
+     * Sets the title for the new itinerary.
+     *
+     * @param title the title to set.
+     */
+    fun setNewItineraryTitle(title: String) {
+        newItineraryBuilder?.title = title
+    }
+
+    /**
+     * Sets the description for the new itinerary.
+     *
+     * @param description the description to set.
+     */
+    fun setNewItineraryDescription(description: String) {
+        newItineraryBuilder?.description = description
+    }
+
+    /**
+     * Checks if the title is valid.
+     *
+     * @param title the title to check.
+     * @return `true` if the title is valid, `false` otherwise.
+     */
+    fun validTitle(title: String): Boolean {
+        return title.length < TITLE_MAX_LENGTH
+    }
+
+    /**
+     * Gets the message to display when the title is invalid.
+     *
+     * @return the invalid title message.
+     */
+    fun invalidTitleMessage(): String {
+        return "title field must be shorter than ${TITLE_MAX_LENGTH} characters"
+    }
+
+    /** Job for tracking user location. */
+    var locationJob: Job? = null
+
+    /** Coroutine scope for managing coroutines. */
+    val coroutineScope = CoroutineScope(Dispatchers.Main)
+
+    /**
+     * Starts tracking the user's location and adds it to the itinerary at the specified interval.
+     *
+     * @param intervalMillis the interval in milliseconds to add locations.
+     * @param addLiveLocation a callback function to handle live location updates.
+     */
+    fun startLocationTracking(intervalMillis: Long, addLiveLocation: (Location) -> Unit) {
+        locationJob?.cancel() // cancel some previous job
+        locationJob =
+            coroutineScope.launch {
+                locationClient.getLocationUpdates(intervalMillis).collect { location ->
+                    newItineraryBuilder?.addLocation(location)
+                    addLiveLocation(location)
+                    Log.d("CreateItineraryViewModel", "build = $newItineraryBuilder")
+                    Log.d(
+                        "CreateItineraryViewModel",
+                        "locations = ${newItineraryBuilder?.locations}"
+                    )
+                }
+            }
+    }
+
+    /** Stops the job tasked with tracking the location. */
+    fun stopLocationTracking() {
+        locationJob?.cancel()
+    }
+
+    /** Cleans up resources when the ViewModel is cleared. */
+    public override fun onCleared() {
+        super.onCleared()
+        coroutineScope.cancel()
+    }
+
+    /**
+     * Gets a list of itinerary fields that have not been set.
+     *
+     * @return a list of ItineraryLabels for the fields that have not been set.
+     * @throws InvalidObjectException if the itinerary builder is `null`.
+     */
+    fun notSetValues(): List<String> {
+        // look if all values have been set
+        val notSetValues: MutableList<String> = mutableListOf()
+
+        if (newItineraryBuilder == null) {
+            // this case shouldn't be possible
+            // add error message
+            throw InvalidObjectException("Itinerary.Builder is `null`")
+        } else {
+            if (newItineraryBuilder!!.price == null) {
+                notSetValues.add(ItineraryLabels.PRICE)
+            }
+            if (newItineraryBuilder!!.time == null) {
+                notSetValues.add(ItineraryLabels.TIME)
+            }
+            if (newItineraryBuilder!!.description == null) {
+                notSetValues.add(ItineraryLabels.DESCRIPTION)
+            }
+            if (newItineraryBuilder!!.title == null) {
+                notSetValues.add(ItineraryLabels.TITLE)
+            }
+            if (newItineraryBuilder!!.locations.isEmpty()) {
+                notSetValues.add(ItineraryLabels.LOCATIONS)
+            }
+            if (newItineraryBuilder!!.tags.isEmpty()) {
+                notSetValues.add(ItineraryLabels.TAGS)
+            }
+        }
+
+        // return the notSetValues (empty if everything has been set)
+        return notSetValues
+    }
+
+    /**
+     * Factory for creating a `CreateItineraryViewModel`.
+     */
+    class Factory(
+        private val itineraryRepository: ItineraryRepository,
+        private val directionsRepository: DirectionsRepository,
+        private val locationsRepository: LocationsRepository,
+        private val locationClient: LocationClient,
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(CreateItineraryViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return CreateItineraryViewModel(
+                    itineraryRepository,
+                    directionsRepository,
+                    locationsRepository,
+                    locationClient
+                ) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/ItineraryViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/ItineraryViewModel.kt
@@ -30,199 +30,191 @@ open class ItineraryViewModel(
     protected val locationsRepository: LocationsRepository,
     protected val locationClient: LocationClient,
 ) : ViewModel() {
-    private var focusedItinerary: Itinerary? = null
+  private var focusedItinerary: Itinerary? = null
 
-    /** @return the itinerary the user has clicked on */
-    fun getFocusedItinerary(): Itinerary? {
-        return focusedItinerary
+  /** @return the itinerary the user has clicked on */
+  fun getFocusedItinerary(): Itinerary? {
+    return focusedItinerary
+  }
+
+  /** changes the focused itinerary to a new one */
+  fun setFocusedItinerary(itinerary: Itinerary?) {
+    focusedItinerary = itinerary
+  }
+
+  /** @return a flow of all public itineraries */
+  fun getAllPublicItineraries(): Flow<List<Itinerary>> {
+    return itineraryRepository.getPublicItineraries()
+  }
+
+  /** @return a flow of all `Itinerary`s associated to the currently logged in user */
+  fun getUserItineraries(userUid: String): Flow<List<Itinerary>> {
+    val ret = itineraryRepository.getUserItineraries(userUid)
+    return ret
+  }
+
+  /** @return the total number of likes from a list of itineraries */
+  fun getItineraryLikes(itineraries: List<Itinerary>): Int {
+
+    var totalLikes = 0
+
+    for (itinerary in itineraries) totalLikes += itinerary.numLikes
+    return totalLikes
+  }
+
+  /** @brief increment likes of a given itinerary */
+  fun incrementItineraryLikes(itinerary: Itinerary) {
+    itinerary.numLikes++
+    itineraryRepository.updateItinerary(itinerary.uid, itinerary)
+  }
+
+  /** @brief decrement likes of a given itinerary */
+  fun decrementItineraryLikes(itinerary: Itinerary) {
+    itinerary.numLikes--
+    itineraryRepository.updateItinerary(itinerary.uid, itinerary)
+  }
+
+  /**
+   * @param preferences user query preferences
+   * @return a list of itineraries matching a user's query preferences
+   * @see Itinerary.scoreFromPreferences for sorting the list from View
+   */
+  fun getItinerariesFromPreferences(preferences: ItineraryPreferences): Flow<List<Itinerary>> {
+    return itineraryRepository.getItinerariesWithTags(preferences.tags)
+  }
+
+  /** @return a sorted list of itineraries scored based on preferences */
+  fun sortItinerariesFromPreferences(
+      itineraries: List<Itinerary>,
+      preferences: ItineraryPreferences
+  ): List<Itinerary> {
+    // invert the sign so that the list is sorted in descending order
+    return itineraries.sortedBy { -it.scoreFromPreferences(preferences) }
+  }
+
+  /** @return list of itineraries queried based on their UIDs */
+  fun getItineraryFromUids(uidList: List<String>): Flow<List<Itinerary>> {
+    return flow {
+      val result = uidList.mapNotNull { uid -> itineraryRepository.getItinerary(uid) }
+      Log.d("ItineraryViewModel", "emitting $result")
+      emit(result)
     }
+  }
 
-    /** changes the focused itinerary to a new one */
-    fun setFocusedItinerary(itinerary: Itinerary?) {
-        focusedItinerary = itinerary
+  /** saves a list of `Itinerary` to persistent storage */
+  fun saveItineraries(itineraries: List<Itinerary>) {
+    viewModelScope.launch { itineraryRepository.writeItinerariesToDisk(itineraries) }
+  }
+
+  /** saves an `Itinerary` to persistent storage */
+  fun saveItinerary(itinerary: Itinerary) {
+    viewModelScope.launch { itineraryRepository.writeItinerariesToDisk(listOf(itinerary)) }
+  }
+
+  /** @brief sets an itinerary in DB */
+  fun setItinerary(itinerary: Itinerary) {
+    viewModelScope.launch { itineraryRepository.setItinerary(itinerary) }
+  }
+
+  /** @brief deletes an itinerary from the database */
+  fun deleteItinerary(itinerary: Itinerary) {
+    itineraryRepository.deleteItinerary(itinerary)
+  }
+
+  fun getNewId(): String {
+    return itineraryRepository.getNewId()
+  }
+
+  private val _polylinePointsLiveData = MutableLiveData<List<LatLng>>()
+  private val polylinePointsLiveData: LiveData<List<LatLng>> =
+      _polylinePointsLiveData // gettable from view
+
+  /**
+   * fetches Polyline points encoded as `LatLng` and updates a `LiveData` variable observed by some
+   * composable function
+   */
+  fun fetchPolylineLocations(itinerary: Itinerary) {
+    Log.d(DEBUG_TAG, "called fetch polyline points")
+    if (itinerary.locations.size < 2) return
+
+    val origin = itinerary.locations.first()
+    val destination = itinerary.locations.last()
+    val originEncoded = "${origin.lat}, ${origin.long}"
+    val destinationEncoded = "${destination.lat}, ${destination.long}"
+
+    val waypoints = itinerary.locations.drop(1).dropLast(1).map { "${it.lat},${it.long}" }
+
+    val key = BuildConfig.MAPS_API_KEY
+    viewModelScope.launch {
+      Log.d(
+          DEBUG_TAG,
+          "origin:$originEncoded :: destination:$destinationEncoded :: waypoints:$waypoints")
+      directionsRepository
+          .getPolylineWayPoints(
+              origin = originEncoded,
+              destination = destinationEncoded,
+              apiKey = key,
+              waypoints = waypoints)
+          .observeForever { response -> _polylinePointsLiveData.value = response ?: listOf() }
     }
+  }
 
-    /** @return a flow of all public itineraries */
-    fun getAllPublicItineraries(): Flow<List<Itinerary>> {
-        return itineraryRepository.getPublicItineraries()
+  /** trivial getter */
+  fun getPolylinePointsLiveData(): LiveData<List<LatLng>> {
+    return polylinePointsLiveData
+  }
+
+  private val _locationsLiveData = MutableLiveData<List<Location>>()
+  private val locationsLiveData: LiveData<List<Location>> = _locationsLiveData // gettable from view
+
+  /* gets the places corresponding to the queried name */
+  fun fetchPlaces(name: String) {
+    val key = BuildConfig.GEOCODE_API_KEY
+    viewModelScope.launch {
+      locationsRepository.getPlaces(name = name, apiKey = key).observeForever { response ->
+        _locationsLiveData.value = response ?: listOf()
+      }
     }
+  }
 
-    /** @return a flow of all `Itinerary`s associated to the currently logged in user */
-    fun getUserItineraries(userUid: String): Flow<List<Itinerary>> {
-        val ret = itineraryRepository.getUserItineraries(userUid)
-        return ret
+  fun getPlacesLiveData(): LiveData<List<Location>> {
+    return locationsLiveData
+  }
+
+  /** @brief get a Flow of the user location updated every second */
+  fun getUserLocation(): Flow<Location> {
+    return locationClient.getLocationUpdates(1000)
+  }
+
+  fun getItineraryGoogleMapsURI(itinerary: Itinerary): String {
+    val locations = itinerary.locations.map { "${it.lat},${it.long}" }
+    val waypoints = locations.dropLast(1).joinToString("|")
+    val uriString = "google.navigation:q=${locations.last()}&waypoints=${waypoints}&mode=w"
+    return uriString
+  }
+
+  fun followItineraryOnGoogleMaps(context: Context, itinerary: Itinerary) {
+    val uri = Uri.parse(getItineraryGoogleMapsURI(itinerary))
+    val intent = Intent(Intent.ACTION_VIEW, uri)
+    intent.setPackage("com.google.android.apps.maps")
+    intent.resolveActivity(context.packageManager)?.let { context.startActivity(intent) }
+  }
+
+  /** Factory for creating a `ItineraryViewModel`. */
+  class Factory(
+      private val itineraryRepository: ItineraryRepository,
+      private val directionsRepository: DirectionsRepository,
+      private val locationsRepository: LocationsRepository,
+      private val locationClient: LocationClient,
+  ) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      if (modelClass.isAssignableFrom(ItineraryViewModel::class.java)) {
+        @Suppress("UNCHECKED_CAST")
+        return ItineraryViewModel(
+            itineraryRepository, directionsRepository, locationsRepository, locationClient)
+            as T
+      }
+      throw IllegalArgumentException("Unknown ViewModel class")
     }
-
-    /** @return the total number of likes from a list of itineraries */
-    fun getItineraryLikes(itineraries: List<Itinerary>): Int {
-
-        var totalLikes = 0
-
-        for (itinerary in itineraries) totalLikes += itinerary.numLikes
-        return totalLikes
-    }
-
-    /** @brief increment likes of a given itinerary */
-    fun incrementItineraryLikes(itinerary: Itinerary) {
-        itinerary.numLikes++
-        itineraryRepository.updateItinerary(itinerary.uid, itinerary)
-    }
-
-    /** @brief decrement likes of a given itinerary */
-    fun decrementItineraryLikes(itinerary: Itinerary) {
-        itinerary.numLikes--
-        itineraryRepository.updateItinerary(itinerary.uid, itinerary)
-    }
-
-    /**
-     * @param preferences user query preferences
-     * @return a list of itineraries matching a user's query preferences
-     * @see Itinerary.scoreFromPreferences for sorting the list from View
-     */
-    fun getItinerariesFromPreferences(preferences: ItineraryPreferences): Flow<List<Itinerary>> {
-        return itineraryRepository.getItinerariesWithTags(preferences.tags)
-    }
-
-    /** @return a sorted list of itineraries scored based on preferences */
-    fun sortItinerariesFromPreferences(
-        itineraries: List<Itinerary>,
-        preferences: ItineraryPreferences
-    ): List<Itinerary> {
-        // invert the sign so that the list is sorted in descending order
-        return itineraries.sortedBy { -it.scoreFromPreferences(preferences) }
-    }
-
-    /** @return list of itineraries queried based on their UIDs */
-    fun getItineraryFromUids(uidList: List<String>): Flow<List<Itinerary>> {
-        return flow {
-            val result = uidList.mapNotNull { uid -> itineraryRepository.getItinerary(uid) }
-            Log.d("ItineraryViewModel", "emitting $result")
-            emit(result)
-        }
-    }
-
-    /** saves a list of `Itinerary` to persistent storage */
-    fun saveItineraries(itineraries: List<Itinerary>) {
-        viewModelScope.launch { itineraryRepository.writeItinerariesToDisk(itineraries) }
-    }
-
-    /** saves an `Itinerary` to persistent storage */
-    fun saveItinerary(itinerary: Itinerary) {
-        viewModelScope.launch { itineraryRepository.writeItinerariesToDisk(listOf(itinerary)) }
-    }
-
-    /** @brief sets an itinerary in DB */
-    fun setItinerary(itinerary: Itinerary) {
-        viewModelScope.launch { itineraryRepository.setItinerary(itinerary) }
-    }
-
-    /** @brief deletes an itinerary from the database */
-    fun deleteItinerary(itinerary: Itinerary) {
-        itineraryRepository.deleteItinerary(itinerary)
-    }
-
-    fun getNewId(): String {
-        return itineraryRepository.getNewId()
-    }
-
-    private val _polylinePointsLiveData = MutableLiveData<List<LatLng>>()
-    private val polylinePointsLiveData: LiveData<List<LatLng>> =
-        _polylinePointsLiveData // gettable from view
-
-    /**
-     * fetches Polyline points encoded as `LatLng` and updates a `LiveData` variable observed by some
-     * composable function
-     */
-    fun fetchPolylineLocations(itinerary: Itinerary) {
-        Log.d(DEBUG_TAG, "called fetch polyline points")
-        if (itinerary.locations.size < 2) return
-
-        val origin = itinerary.locations.first()
-        val destination = itinerary.locations.last()
-        val originEncoded = "${origin.lat}, ${origin.long}"
-        val destinationEncoded = "${destination.lat}, ${destination.long}"
-
-        val waypoints = itinerary.locations.drop(1).dropLast(1).map { "${it.lat},${it.long}" }
-
-        val key = BuildConfig.MAPS_API_KEY
-        viewModelScope.launch {
-            Log.d(
-                DEBUG_TAG,
-                "origin:$originEncoded :: destination:$destinationEncoded :: waypoints:$waypoints"
-            )
-            directionsRepository
-                .getPolylineWayPoints(
-                    origin = originEncoded,
-                    destination = destinationEncoded,
-                    apiKey = key,
-                    waypoints = waypoints
-                )
-                .observeForever { response -> _polylinePointsLiveData.value = response ?: listOf() }
-        }
-    }
-
-    /** trivial getter */
-    fun getPolylinePointsLiveData(): LiveData<List<LatLng>> {
-        return polylinePointsLiveData
-    }
-
-    private val _locationsLiveData = MutableLiveData<List<Location>>()
-    private val locationsLiveData: LiveData<List<Location>> =
-        _locationsLiveData // gettable from view
-
-    /* gets the places corresponding to the queried name */
-    fun fetchPlaces(name: String) {
-        val key = BuildConfig.GEOCODE_API_KEY
-        viewModelScope.launch {
-            locationsRepository.getPlaces(name = name, apiKey = key).observeForever { response ->
-                _locationsLiveData.value = response ?: listOf()
-            }
-        }
-    }
-
-    fun getPlacesLiveData(): LiveData<List<Location>> {
-        return locationsLiveData
-    }
-
-    /** @brief get a Flow of the user location updated every second */
-    fun getUserLocation(): Flow<Location> {
-        return locationClient.getLocationUpdates(1000)
-    }
-
-    fun getItineraryGoogleMapsURI(itinerary: Itinerary): String {
-        val locations = itinerary.locations.map { "${it.lat},${it.long}" }
-        val waypoints = locations.dropLast(1).joinToString("|")
-        val uriString = "google.navigation:q=${locations.last()}&waypoints=${waypoints}&mode=w"
-        return uriString
-    }
-
-    fun followItineraryOnGoogleMaps(context: Context, itinerary: Itinerary) {
-        val uri = Uri.parse(getItineraryGoogleMapsURI(itinerary))
-        val intent = Intent(Intent.ACTION_VIEW, uri)
-        intent.setPackage("com.google.android.apps.maps")
-        intent.resolveActivity(context.packageManager)?.let { context.startActivity(intent) }
-    }
-
-    /**
-     * Factory for creating a `ItineraryViewModel`.
-     */
-    class Factory(
-        private val itineraryRepository: ItineraryRepository,
-        private val directionsRepository: DirectionsRepository,
-        private val locationsRepository: LocationsRepository,
-        private val locationClient: LocationClient,
-    ) : ViewModelProvider.Factory {
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            if (modelClass.isAssignableFrom(ItineraryViewModel::class.java)) {
-                @Suppress("UNCHECKED_CAST")
-                return ItineraryViewModel(
-                    itineraryRepository,
-                    directionsRepository,
-                    locationsRepository,
-                    locationClient
-                ) as T
-            }
-            throw IllegalArgumentException("Unknown ViewModel class")
-        }
-    }
+  }
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/ItineraryViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/ItineraryViewModel.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.github.wanderwise_inc.app.BuildConfig
 import com.github.wanderwise_inc.app.data.DirectionsRepository
@@ -21,6 +22,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 
 private const val DEBUG_TAG: String = "ITINERARY_VIEWMODEL"
+
 /** @brief ViewModel class for providing `Location`s and `Itinerary`s and related logic */
 open class ItineraryViewModel(
     protected val itineraryRepository: ItineraryRepository,
@@ -28,173 +30,199 @@ open class ItineraryViewModel(
     protected val locationsRepository: LocationsRepository,
     protected val locationClient: LocationClient,
 ) : ViewModel() {
-  private var focusedItinerary: Itinerary? = null
+    private var focusedItinerary: Itinerary? = null
 
-  /** @return the itinerary the user has clicked on */
-  fun getFocusedItinerary(): Itinerary? {
-    return focusedItinerary
-  }
-
-  /** changes the focused itinerary to a new one */
-  fun setFocusedItinerary(itinerary: Itinerary?) {
-    focusedItinerary = itinerary
-  }
-
-  /** @return a flow of all public itineraries */
-  fun getAllPublicItineraries(): Flow<List<Itinerary>> {
-    return itineraryRepository.getPublicItineraries()
-  }
-
-  /** @return a flow of all `Itinerary`s associated to the currently logged in user */
-  fun getUserItineraries(userUid: String): Flow<List<Itinerary>> {
-    val ret = itineraryRepository.getUserItineraries(userUid)
-    return ret
-  }
-
-  /** @return the total number of likes from a list of itineraries */
-  fun getItineraryLikes(itineraries: List<Itinerary>): Int {
-
-    var totalLikes = 0
-
-    for (itinerary in itineraries) totalLikes += itinerary.numLikes
-    return totalLikes
-  }
-
-  /** @brief increment likes of a given itinerary */
-  fun incrementItineraryLikes(itinerary: Itinerary) {
-    itinerary.numLikes++
-    itineraryRepository.updateItinerary(itinerary.uid, itinerary)
-  }
-
-  /** @brief decrement likes of a given itinerary */
-  fun decrementItineraryLikes(itinerary: Itinerary) {
-    itinerary.numLikes--
-    itineraryRepository.updateItinerary(itinerary.uid, itinerary)
-  }
-
-  /**
-   * @param preferences user query preferences
-   * @return a list of itineraries matching a user's query preferences
-   * @see Itinerary.scoreFromPreferences for sorting the list from View
-   */
-  fun getItinerariesFromPreferences(preferences: ItineraryPreferences): Flow<List<Itinerary>> {
-    return itineraryRepository.getItinerariesWithTags(preferences.tags)
-  }
-
-  /** @return a sorted list of itineraries scored based on preferences */
-  fun sortItinerariesFromPreferences(
-      itineraries: List<Itinerary>,
-      preferences: ItineraryPreferences
-  ): List<Itinerary> {
-    // invert the sign so that the list is sorted in descending order
-    return itineraries.sortedBy { -it.scoreFromPreferences(preferences) }
-  }
-
-  /** @return list of itineraries queried based on their UIDs */
-  fun getItineraryFromUids(uidList: List<String>): Flow<List<Itinerary>> {
-    return flow {
-      val result = uidList.mapNotNull { uid -> itineraryRepository.getItinerary(uid) }
-      Log.d("ItineraryViewModel", "emitting $result")
-      emit(result)
+    /** @return the itinerary the user has clicked on */
+    fun getFocusedItinerary(): Itinerary? {
+        return focusedItinerary
     }
-  }
 
-  /** saves a list of `Itinerary` to persistent storage */
-  fun saveItineraries(itineraries: List<Itinerary>) {
-    viewModelScope.launch { itineraryRepository.writeItinerariesToDisk(itineraries) }
-  }
-
-  /** saves an `Itinerary` to persistent storage */
-  fun saveItinerary(itinerary: Itinerary) {
-    viewModelScope.launch { itineraryRepository.writeItinerariesToDisk(listOf(itinerary)) }
-  }
-
-  /** @brief sets an itinerary in DB */
-  fun setItinerary(itinerary: Itinerary) {
-    viewModelScope.launch { itineraryRepository.setItinerary(itinerary) }
-  }
-
-  /** @brief deletes an itinerary from the database */
-  fun deleteItinerary(itinerary: Itinerary) {
-    itineraryRepository.deleteItinerary(itinerary)
-  }
-
-  fun getNewId(): String {
-    return itineraryRepository.getNewId()
-  }
-
-  private val _polylinePointsLiveData = MutableLiveData<List<LatLng>>()
-  private val polylinePointsLiveData: LiveData<List<LatLng>> =
-      _polylinePointsLiveData // gettable from view
-
-  /**
-   * fetches Polyline points encoded as `LatLng` and updates a `LiveData` variable observed by some
-   * composable function
-   */
-  fun fetchPolylineLocations(itinerary: Itinerary) {
-    Log.d(DEBUG_TAG, "called fetch polyline points")
-    if (itinerary.locations.size < 2) return
-
-    val origin = itinerary.locations.first()
-    val destination = itinerary.locations.last()
-    val originEncoded = "${origin.lat}, ${origin.long}"
-    val destinationEncoded = "${destination.lat}, ${destination.long}"
-
-    val waypoints = itinerary.locations.drop(1).dropLast(1).map { "${it.lat},${it.long}" }
-
-    val key = BuildConfig.MAPS_API_KEY
-    viewModelScope.launch {
-      Log.d(
-          DEBUG_TAG,
-          "origin:$originEncoded :: destination:$destinationEncoded :: waypoints:$waypoints")
-      directionsRepository
-          .getPolylineWayPoints(
-              origin = originEncoded,
-              destination = destinationEncoded,
-              apiKey = key,
-              waypoints = waypoints)
-          .observeForever { response -> _polylinePointsLiveData.value = response ?: listOf() }
+    /** changes the focused itinerary to a new one */
+    fun setFocusedItinerary(itinerary: Itinerary?) {
+        focusedItinerary = itinerary
     }
-  }
 
-  /** trivial getter */
-  fun getPolylinePointsLiveData(): LiveData<List<LatLng>> {
-    return polylinePointsLiveData
-  }
-
-  private val _locationsLiveData = MutableLiveData<List<Location>>()
-  private val locationsLiveData: LiveData<List<Location>> = _locationsLiveData // gettable from view
-
-  /* gets the places corresponding to the queried name */
-  fun fetchPlaces(name: String) {
-    val key = BuildConfig.GEOCODE_API_KEY
-    viewModelScope.launch {
-      locationsRepository.getPlaces(name = name, apiKey = key).observeForever { response ->
-        _locationsLiveData.value = response ?: listOf()
-      }
+    /** @return a flow of all public itineraries */
+    fun getAllPublicItineraries(): Flow<List<Itinerary>> {
+        return itineraryRepository.getPublicItineraries()
     }
-  }
 
-  fun getPlacesLiveData(): LiveData<List<Location>> {
-    return locationsLiveData
-  }
+    /** @return a flow of all `Itinerary`s associated to the currently logged in user */
+    fun getUserItineraries(userUid: String): Flow<List<Itinerary>> {
+        val ret = itineraryRepository.getUserItineraries(userUid)
+        return ret
+    }
 
-  /** @brief get a Flow of the user location updated every second */
-  fun getUserLocation(): Flow<Location> {
-    return locationClient.getLocationUpdates(1000)
-  }
+    /** @return the total number of likes from a list of itineraries */
+    fun getItineraryLikes(itineraries: List<Itinerary>): Int {
 
-  fun getItineraryGoogleMapsURI(itinerary: Itinerary): String {
-    val locations = itinerary.locations.map { "${it.lat},${it.long}" }
-    val waypoints = locations.dropLast(1).joinToString("|")
-    val uriString = "google.navigation:q=${locations.last()}&waypoints=${waypoints}&mode=w"
-    return uriString
-  }
+        var totalLikes = 0
 
-  fun followItineraryOnGoogleMaps(context: Context, itinerary: Itinerary) {
-    val uri = Uri.parse(getItineraryGoogleMapsURI(itinerary))
-    val intent = Intent(Intent.ACTION_VIEW, uri)
-    intent.setPackage("com.google.android.apps.maps")
-    intent.resolveActivity(context.packageManager)?.let { context.startActivity(intent) }
-  }
+        for (itinerary in itineraries) totalLikes += itinerary.numLikes
+        return totalLikes
+    }
+
+    /** @brief increment likes of a given itinerary */
+    fun incrementItineraryLikes(itinerary: Itinerary) {
+        itinerary.numLikes++
+        itineraryRepository.updateItinerary(itinerary.uid, itinerary)
+    }
+
+    /** @brief decrement likes of a given itinerary */
+    fun decrementItineraryLikes(itinerary: Itinerary) {
+        itinerary.numLikes--
+        itineraryRepository.updateItinerary(itinerary.uid, itinerary)
+    }
+
+    /**
+     * @param preferences user query preferences
+     * @return a list of itineraries matching a user's query preferences
+     * @see Itinerary.scoreFromPreferences for sorting the list from View
+     */
+    fun getItinerariesFromPreferences(preferences: ItineraryPreferences): Flow<List<Itinerary>> {
+        return itineraryRepository.getItinerariesWithTags(preferences.tags)
+    }
+
+    /** @return a sorted list of itineraries scored based on preferences */
+    fun sortItinerariesFromPreferences(
+        itineraries: List<Itinerary>,
+        preferences: ItineraryPreferences
+    ): List<Itinerary> {
+        // invert the sign so that the list is sorted in descending order
+        return itineraries.sortedBy { -it.scoreFromPreferences(preferences) }
+    }
+
+    /** @return list of itineraries queried based on their UIDs */
+    fun getItineraryFromUids(uidList: List<String>): Flow<List<Itinerary>> {
+        return flow {
+            val result = uidList.mapNotNull { uid -> itineraryRepository.getItinerary(uid) }
+            Log.d("ItineraryViewModel", "emitting $result")
+            emit(result)
+        }
+    }
+
+    /** saves a list of `Itinerary` to persistent storage */
+    fun saveItineraries(itineraries: List<Itinerary>) {
+        viewModelScope.launch { itineraryRepository.writeItinerariesToDisk(itineraries) }
+    }
+
+    /** saves an `Itinerary` to persistent storage */
+    fun saveItinerary(itinerary: Itinerary) {
+        viewModelScope.launch { itineraryRepository.writeItinerariesToDisk(listOf(itinerary)) }
+    }
+
+    /** @brief sets an itinerary in DB */
+    fun setItinerary(itinerary: Itinerary) {
+        viewModelScope.launch { itineraryRepository.setItinerary(itinerary) }
+    }
+
+    /** @brief deletes an itinerary from the database */
+    fun deleteItinerary(itinerary: Itinerary) {
+        itineraryRepository.deleteItinerary(itinerary)
+    }
+
+    fun getNewId(): String {
+        return itineraryRepository.getNewId()
+    }
+
+    private val _polylinePointsLiveData = MutableLiveData<List<LatLng>>()
+    private val polylinePointsLiveData: LiveData<List<LatLng>> =
+        _polylinePointsLiveData // gettable from view
+
+    /**
+     * fetches Polyline points encoded as `LatLng` and updates a `LiveData` variable observed by some
+     * composable function
+     */
+    fun fetchPolylineLocations(itinerary: Itinerary) {
+        Log.d(DEBUG_TAG, "called fetch polyline points")
+        if (itinerary.locations.size < 2) return
+
+        val origin = itinerary.locations.first()
+        val destination = itinerary.locations.last()
+        val originEncoded = "${origin.lat}, ${origin.long}"
+        val destinationEncoded = "${destination.lat}, ${destination.long}"
+
+        val waypoints = itinerary.locations.drop(1).dropLast(1).map { "${it.lat},${it.long}" }
+
+        val key = BuildConfig.MAPS_API_KEY
+        viewModelScope.launch {
+            Log.d(
+                DEBUG_TAG,
+                "origin:$originEncoded :: destination:$destinationEncoded :: waypoints:$waypoints"
+            )
+            directionsRepository
+                .getPolylineWayPoints(
+                    origin = originEncoded,
+                    destination = destinationEncoded,
+                    apiKey = key,
+                    waypoints = waypoints
+                )
+                .observeForever { response -> _polylinePointsLiveData.value = response ?: listOf() }
+        }
+    }
+
+    /** trivial getter */
+    fun getPolylinePointsLiveData(): LiveData<List<LatLng>> {
+        return polylinePointsLiveData
+    }
+
+    private val _locationsLiveData = MutableLiveData<List<Location>>()
+    private val locationsLiveData: LiveData<List<Location>> =
+        _locationsLiveData // gettable from view
+
+    /* gets the places corresponding to the queried name */
+    fun fetchPlaces(name: String) {
+        val key = BuildConfig.GEOCODE_API_KEY
+        viewModelScope.launch {
+            locationsRepository.getPlaces(name = name, apiKey = key).observeForever { response ->
+                _locationsLiveData.value = response ?: listOf()
+            }
+        }
+    }
+
+    fun getPlacesLiveData(): LiveData<List<Location>> {
+        return locationsLiveData
+    }
+
+    /** @brief get a Flow of the user location updated every second */
+    fun getUserLocation(): Flow<Location> {
+        return locationClient.getLocationUpdates(1000)
+    }
+
+    fun getItineraryGoogleMapsURI(itinerary: Itinerary): String {
+        val locations = itinerary.locations.map { "${it.lat},${it.long}" }
+        val waypoints = locations.dropLast(1).joinToString("|")
+        val uriString = "google.navigation:q=${locations.last()}&waypoints=${waypoints}&mode=w"
+        return uriString
+    }
+
+    fun followItineraryOnGoogleMaps(context: Context, itinerary: Itinerary) {
+        val uri = Uri.parse(getItineraryGoogleMapsURI(itinerary))
+        val intent = Intent(Intent.ACTION_VIEW, uri)
+        intent.setPackage("com.google.android.apps.maps")
+        intent.resolveActivity(context.packageManager)?.let { context.startActivity(intent) }
+    }
+
+    /**
+     * Factory for creating a `ItineraryViewModel`.
+     */
+    class Factory(
+        private val itineraryRepository: ItineraryRepository,
+        private val directionsRepository: DirectionsRepository,
+        private val locationsRepository: LocationsRepository,
+        private val locationClient: LocationClient,
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(ItineraryViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return ItineraryViewModel(
+                    itineraryRepository,
+                    directionsRepository,
+                    locationsRepository,
+                    locationClient
+                ) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/LoginViewModel.kt
@@ -5,8 +5,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.github.wanderwise_inc.app.data.ImageRepository
-import com.github.wanderwise_inc.app.data.ProfileRepository
 import com.github.wanderwise_inc.app.data.SignInLauncher
 import com.google.firebase.auth.FirebaseUser
 import kotlinx.coroutines.flow.first

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/LoginViewModel.kt
@@ -4,6 +4,9 @@ import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.github.wanderwise_inc.app.data.ImageRepository
+import com.github.wanderwise_inc.app.data.ProfileRepository
 import com.github.wanderwise_inc.app.data.SignInLauncher
 import com.google.firebase.auth.FirebaseUser
 import kotlinx.coroutines.flow.first
@@ -19,66 +22,82 @@ class LoginViewModel(
     private val signInLauncher: SignInLauncher,
     private val isNetworkAvailable: Boolean,
 ) : ViewModel() {
-  // The state of the sign-in process
-  private val _signInState = MutableLiveData(SignInState.NONE)
-  val signInState: LiveData<SignInState>
-    get() = _signInState
+    // The state of the sign-in process
+    private val _signInState = MutableLiveData(SignInState.NONE)
+    val signInState: LiveData<SignInState>
+        get() = _signInState
 
-  /** Launches the sign-in process. */
-  fun signIn() {
-    if (isNetworkAvailable) signInLauncher.signIn()
-    else {
-      Log.d("LoginViewModel", "Network unavailable")
-      _signInState.value = SignInState.OFFLINE
-    }
-  }
-
-  /**
-   * Handles the result of the sign-in process.
-   *
-   * @param profileViewModel The profile view model.
-   * @param user The signed-in user.
-   */
-  suspend fun handleSignInResult(
-      profileViewModel: ProfileViewModel,
-      user: FirebaseUser?,
-  ) {
-    user?.let { signInSucceeded(profileViewModel, it) } ?: signInFailed()
-  }
-
-  /** Sets the sign-in state to [SignInState.FAILURE]. */
-  private fun signInFailed() {
-    _signInState.value = SignInState.FAILURE
-  }
-
-  /**
-   * Sets the sign-in state to [SignInState.SUCCESS] and updates the active profile.
-   *
-   * @param profileViewModel The profile view model.
-   * @param user The signed-in user.
-   */
-  private suspend fun signInSucceeded(profileViewModel: ProfileViewModel, user: FirebaseUser) {
-    // Get the user from database
-    val currentProfile = profileViewModel.getProfile(user.uid).first()
-
-    if (currentProfile != null) {
-      profileViewModel.setActiveProfile(currentProfile)
-    } else {
-      val newProfile = profileViewModel.createProfileFromFirebaseUser(user)
-
-      // Set the user to the database
-      profileViewModel.setProfile(newProfile)
-      profileViewModel.setActiveProfile(newProfile)
+    /** Launches the sign-in process. */
+    fun signIn() {
+        if (isNetworkAvailable) signInLauncher.signIn()
+        else {
+            Log.d("LoginViewModel", "Network unavailable")
+            _signInState.value = SignInState.OFFLINE
+        }
     }
 
-    _signInState.value = SignInState.SUCCESS
-  }
+    /**
+     * Handles the result of the sign-in process.
+     *
+     * @param profileViewModel The profile view model.
+     * @param user The signed-in user.
+     */
+    suspend fun handleSignInResult(
+        profileViewModel: ProfileViewModel,
+        user: FirebaseUser?,
+    ) {
+        user?.let { signInSucceeded(profileViewModel, it) } ?: signInFailed()
+    }
+
+    /** Sets the sign-in state to [SignInState.FAILURE]. */
+    private fun signInFailed() {
+        _signInState.value = SignInState.FAILURE
+    }
+
+    /**
+     * Sets the sign-in state to [SignInState.SUCCESS] and updates the active profile.
+     *
+     * @param profileViewModel The profile view model.
+     * @param user The signed-in user.
+     */
+    private suspend fun signInSucceeded(profileViewModel: ProfileViewModel, user: FirebaseUser) {
+        // Get the user from database
+        val currentProfile = profileViewModel.getProfile(user.uid).first()
+
+        if (currentProfile != null) {
+            profileViewModel.setActiveProfile(currentProfile)
+        } else {
+            val newProfile = profileViewModel.createProfileFromFirebaseUser(user)
+
+            // Set the user to the database
+            profileViewModel.setProfile(newProfile)
+            profileViewModel.setActiveProfile(newProfile)
+        }
+
+        _signInState.value = SignInState.SUCCESS
+    }
+
+    /**
+     * Factory for creating a `LoginViewModel`.
+     */
+    class Factory(
+        private val signInLauncher: SignInLauncher,
+        private val isNetworkAvailable: Boolean,
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(LoginViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return LoginViewModel(signInLauncher, isNetworkAvailable) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
 }
 
 /** The state of the sign-in process. */
 enum class SignInState {
-  NONE,
-  SUCCESS,
-  FAILURE,
-  OFFLINE,
+    NONE,
+    SUCCESS,
+    FAILURE,
+    OFFLINE,
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/LoginViewModel.kt
@@ -20,82 +20,79 @@ class LoginViewModel(
     private val signInLauncher: SignInLauncher,
     private val isNetworkAvailable: Boolean,
 ) : ViewModel() {
-    // The state of the sign-in process
-    private val _signInState = MutableLiveData(SignInState.NONE)
-    val signInState: LiveData<SignInState>
-        get() = _signInState
+  // The state of the sign-in process
+  private val _signInState = MutableLiveData(SignInState.NONE)
+  val signInState: LiveData<SignInState>
+    get() = _signInState
 
-    /** Launches the sign-in process. */
-    fun signIn() {
-        if (isNetworkAvailable) signInLauncher.signIn()
-        else {
-            Log.d("LoginViewModel", "Network unavailable")
-            _signInState.value = SignInState.OFFLINE
-        }
+  /** Launches the sign-in process. */
+  fun signIn() {
+    if (isNetworkAvailable) signInLauncher.signIn()
+    else {
+      Log.d("LoginViewModel", "Network unavailable")
+      _signInState.value = SignInState.OFFLINE
+    }
+  }
+
+  /**
+   * Handles the result of the sign-in process.
+   *
+   * @param profileViewModel The profile view model.
+   * @param user The signed-in user.
+   */
+  suspend fun handleSignInResult(
+      profileViewModel: ProfileViewModel,
+      user: FirebaseUser?,
+  ) {
+    user?.let { signInSucceeded(profileViewModel, it) } ?: signInFailed()
+  }
+
+  /** Sets the sign-in state to [SignInState.FAILURE]. */
+  private fun signInFailed() {
+    _signInState.value = SignInState.FAILURE
+  }
+
+  /**
+   * Sets the sign-in state to [SignInState.SUCCESS] and updates the active profile.
+   *
+   * @param profileViewModel The profile view model.
+   * @param user The signed-in user.
+   */
+  private suspend fun signInSucceeded(profileViewModel: ProfileViewModel, user: FirebaseUser) {
+    // Get the user from database
+    val currentProfile = profileViewModel.getProfile(user.uid).first()
+
+    if (currentProfile != null) {
+      profileViewModel.setActiveProfile(currentProfile)
+    } else {
+      val newProfile = profileViewModel.createProfileFromFirebaseUser(user)
+
+      // Set the user to the database
+      profileViewModel.setProfile(newProfile)
+      profileViewModel.setActiveProfile(newProfile)
     }
 
-    /**
-     * Handles the result of the sign-in process.
-     *
-     * @param profileViewModel The profile view model.
-     * @param user The signed-in user.
-     */
-    suspend fun handleSignInResult(
-        profileViewModel: ProfileViewModel,
-        user: FirebaseUser?,
-    ) {
-        user?.let { signInSucceeded(profileViewModel, it) } ?: signInFailed()
+    _signInState.value = SignInState.SUCCESS
+  }
+
+  /** Factory for creating a `LoginViewModel`. */
+  class Factory(
+      private val signInLauncher: SignInLauncher,
+      private val isNetworkAvailable: Boolean,
+  ) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      if (modelClass.isAssignableFrom(LoginViewModel::class.java)) {
+        @Suppress("UNCHECKED_CAST") return LoginViewModel(signInLauncher, isNetworkAvailable) as T
+      }
+      throw IllegalArgumentException("Unknown ViewModel class")
     }
-
-    /** Sets the sign-in state to [SignInState.FAILURE]. */
-    private fun signInFailed() {
-        _signInState.value = SignInState.FAILURE
-    }
-
-    /**
-     * Sets the sign-in state to [SignInState.SUCCESS] and updates the active profile.
-     *
-     * @param profileViewModel The profile view model.
-     * @param user The signed-in user.
-     */
-    private suspend fun signInSucceeded(profileViewModel: ProfileViewModel, user: FirebaseUser) {
-        // Get the user from database
-        val currentProfile = profileViewModel.getProfile(user.uid).first()
-
-        if (currentProfile != null) {
-            profileViewModel.setActiveProfile(currentProfile)
-        } else {
-            val newProfile = profileViewModel.createProfileFromFirebaseUser(user)
-
-            // Set the user to the database
-            profileViewModel.setProfile(newProfile)
-            profileViewModel.setActiveProfile(newProfile)
-        }
-
-        _signInState.value = SignInState.SUCCESS
-    }
-
-    /**
-     * Factory for creating a `LoginViewModel`.
-     */
-    class Factory(
-        private val signInLauncher: SignInLauncher,
-        private val isNetworkAvailable: Boolean,
-    ) : ViewModelProvider.Factory {
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            if (modelClass.isAssignableFrom(LoginViewModel::class.java)) {
-                @Suppress("UNCHECKED_CAST")
-                return LoginViewModel(signInLauncher, isNetworkAvailable) as T
-            }
-            throw IllegalArgumentException("Unknown ViewModel class")
-        }
-    }
+  }
 }
 
 /** The state of the sign-in process. */
 enum class SignInState {
-    NONE,
-    SUCCESS,
-    FAILURE,
-    OFFLINE,
+  NONE,
+  SUCCESS,
+  FAILURE,
+  OFFLINE,
 }

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/ProfileViewModel.kt
@@ -16,138 +16,133 @@ class ProfileViewModel(
     private val profileRepository: ProfileRepository,
     private val imageRepository: ImageRepository
 ) : ViewModel() {
-    private var isSignInComplete = false // set on sign-in success
+  private var isSignInComplete = false // set on sign-in success
 
-    /** The `Profile` of the currently signed-in user. Set on sign-in */
-    private lateinit var activeProfile: Profile
+  /** The `Profile` of the currently signed-in user. Set on sign-in */
+  private lateinit var activeProfile: Profile
 
-    init {
-        Log.d("ProfileViewModel", "ProfileViewModel created")
+  init {
+    Log.d("ProfileViewModel", "ProfileViewModel created")
+  }
+
+  /** @return flow of a user profile */
+  fun getProfile(userUid: String): Flow<Profile?> {
+    Log.d("ProfileViewModel", "Fetching profile for user: $userUid")
+    return profileRepository.getProfile(userUid)
+  }
+
+  /** @return all profiles in data source */
+  fun getAllProfiles(): Flow<List<Profile>> {
+    return profileRepository.getAllProfiles()
+  }
+
+  /** Sets a profile in data source */
+  fun setProfile(profile: Profile) {
+    profileRepository.setProfile(profile)
+  }
+
+  /** Deletes a profile from the data source */
+  fun deleteProfile(profile: Profile) {
+    profileRepository.deleteProfile(profile)
+  }
+
+  /** @return the profile picture of a user as a bitmap flow for asynchronous drawing */
+  fun getProfilePicture(profile: Profile): Flow<Uri?> {
+    return imageRepository.fetchImage("profilePicture/${profile.userUid}")
+  }
+
+  /** @return the default profile picture asset */
+  fun getDefaultProfilePicture(): Flow<Uri?> {
+    return imageRepository.fetchImage("profilePicture/defaultProfilePicture.jpg")
+  }
+
+  /**
+   * Adds a liked `Itinerary` to the `Profile` with user-uid `userUid` except if this is the default
+   * offline profile, in which case this call has no effect
+   */
+  fun addLikedItinerary(userUid: String, itineraryUid: String) {
+    if (userUid == DEFAULT_OFFLINE_PROFILE.userUid) return
+    profileRepository.addItineraryToLiked(userUid, itineraryUid)
+  }
+
+  /**
+   * Removes a liked `Itinerary` from the `Profile` with user-uid `userUid` except if this is the
+   * default offline profile, in which case this call has no effect
+   */
+  fun removeLikedItinerary(userUid: String, itineraryUid: String) {
+    if (userUid == DEFAULT_OFFLINE_PROFILE.userUid) return
+    profileRepository.removeItineraryFromLiked(userUid, itineraryUid)
+  }
+
+  /**
+   * @return `true` iff the itinerary with uid `itineraryUid` is liked by the profile with user-uid
+   *   `userUid`
+   */
+  suspend fun checkIfItineraryIsLiked(userUid: String, itineraryUid: String): Boolean {
+    if (userUid == DEFAULT_OFFLINE_PROFILE.userUid) return false
+    return profileRepository.checkIfItineraryIsLiked(userUid, itineraryUid)
+  }
+
+  /** @return `true` iff the itinerary with uid `itineraryUid` is liked by the active profile */
+  suspend fun checkIfItineraryIsLikedByActiveProfile(itineraryUid: String): Boolean {
+    return if (isSignInComplete)
+        profileRepository.checkIfItineraryIsLiked(getUserUid(), itineraryUid)
+    else false
+  }
+
+  /**
+   * @return all of the profile's liked itineraries, or an empty list if there is no actively signed
+   *   in profile
+   */
+  fun getLikedItineraries(userUid: String): Flow<List<String>> {
+    return profileRepository.getLikedItineraries(userUid)
+  }
+
+  /** Sets the active profile. Called on sign-in and only called once */
+  fun setActiveProfile(profile: Profile) {
+    if (!isSignInComplete) {
+      activeProfile = profile
+      isSignInComplete = true
     }
+  }
 
-    /** @return flow of a user profile */
-    fun getProfile(userUid: String): Flow<Profile?> {
-        Log.d("ProfileViewModel", "Fetching profile for user: $userUid")
-        return profileRepository.getProfile(userUid)
+  /**
+   * @return the profile of the active user, as initialized at sign-in. If sign-in in was
+   *   unsuccessful, this will return `DEFAULT_OFFLINE_PROFILE` as defined in `Profile.kt`
+   */
+  fun getActiveProfile(): Profile = activeProfile
+
+  /** @return the UID of the signed in profile */
+  fun getUserUid(): String = activeProfile.userUid
+
+  /** Updates liked itineraries of active profile locally */
+  fun setActiveProfileLikedItineraries(itineraries: List<Itinerary>) {
+    if (itineraries.isNotEmpty()) {
+      Log.d("ProfileViewModel", "Updating active profile liked: ${itineraries.map { it.uid }}")
+      activeProfile.likedItinerariesUid.clear()
+      activeProfile.likedItinerariesUid.addAll(itineraries.map { it.uid })
     }
+  }
 
-    /** @return all profiles in data source */
-    fun getAllProfiles(): Flow<List<Profile>> {
-        return profileRepository.getAllProfiles()
+  /** Creates a profile from a Firebase user */
+  fun createProfileFromFirebaseUser(user: FirebaseUser): Profile {
+    val uid = user.uid
+    val displayName = user.displayName ?: ""
+    val bio = ""
+
+    return Profile(userUid = uid, displayName = displayName, bio = bio)
+  }
+
+  /** Factory for creating a `ProfileViewModel` */
+  class Factory(
+      private val profileRepository: ProfileRepository,
+      private val imageRepository: ImageRepository
+  ) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      if (modelClass.isAssignableFrom(ProfileViewModel::class.java)) {
+        @Suppress("UNCHECKED_CAST") return ProfileViewModel(profileRepository, imageRepository) as T
+      }
+      throw IllegalArgumentException("Unknown ViewModel class")
     }
-
-    /** Sets a profile in data source */
-    fun setProfile(profile: Profile) {
-        profileRepository.setProfile(profile)
-    }
-
-    /** Deletes a profile from the data source */
-    fun deleteProfile(profile: Profile) {
-        profileRepository.deleteProfile(profile)
-    }
-
-    /** @return the profile picture of a user as a bitmap flow for asynchronous drawing */
-    fun getProfilePicture(profile: Profile): Flow<Uri?> {
-        return imageRepository.fetchImage("profilePicture/${profile.userUid}")
-    }
-
-    /** @return the default profile picture asset */
-    fun getDefaultProfilePicture(): Flow<Uri?> {
-        return imageRepository.fetchImage("profilePicture/defaultProfilePicture.jpg")
-    }
-
-    /**
-     * Adds a liked `Itinerary` to the `Profile` with user-uid `userUid` except if this is the default
-     * offline profile, in which case this call has no effect
-     */
-    fun addLikedItinerary(userUid: String, itineraryUid: String) {
-        if (userUid == DEFAULT_OFFLINE_PROFILE.userUid) return
-        profileRepository.addItineraryToLiked(userUid, itineraryUid)
-    }
-
-    /**
-     * Removes a liked `Itinerary` from the `Profile` with user-uid `userUid` except if this is the
-     * default offline profile, in which case this call has no effect
-     */
-    fun removeLikedItinerary(userUid: String, itineraryUid: String) {
-        if (userUid == DEFAULT_OFFLINE_PROFILE.userUid) return
-        profileRepository.removeItineraryFromLiked(userUid, itineraryUid)
-    }
-
-    /**
-     * @return `true` iff the itinerary with uid `itineraryUid` is liked by the profile with user-uid
-     *   `userUid`
-     */
-    suspend fun checkIfItineraryIsLiked(userUid: String, itineraryUid: String): Boolean {
-        if (userUid == DEFAULT_OFFLINE_PROFILE.userUid) return false
-        return profileRepository.checkIfItineraryIsLiked(userUid, itineraryUid)
-    }
-
-    /** @return `true` iff the itinerary with uid `itineraryUid` is liked by the active profile */
-    suspend fun checkIfItineraryIsLikedByActiveProfile(itineraryUid: String): Boolean {
-        return if (isSignInComplete)
-            profileRepository.checkIfItineraryIsLiked(getUserUid(), itineraryUid)
-        else false
-    }
-
-    /**
-     * @return all of the profile's liked itineraries, or an empty list if there is no actively signed
-     *   in profile
-     */
-    fun getLikedItineraries(userUid: String): Flow<List<String>> {
-        return profileRepository.getLikedItineraries(userUid)
-    }
-
-    /** Sets the active profile. Called on sign-in and only called once */
-    fun setActiveProfile(profile: Profile) {
-        if (!isSignInComplete) {
-            activeProfile = profile
-            isSignInComplete = true
-        }
-    }
-
-    /**
-     * @return the profile of the active user, as initialized at sign-in. If sign-in in was
-     *   unsuccessful, this will return `DEFAULT_OFFLINE_PROFILE` as defined in `Profile.kt`
-     */
-    fun getActiveProfile(): Profile = activeProfile
-
-    /** @return the UID of the signed in profile */
-    fun getUserUid(): String = activeProfile.userUid
-
-    /** Updates liked itineraries of active profile locally */
-    fun setActiveProfileLikedItineraries(itineraries: List<Itinerary>) {
-        if (itineraries.isNotEmpty()) {
-            Log.d(
-                "ProfileViewModel",
-                "Updating active profile liked: ${itineraries.map { it.uid }}"
-            )
-            activeProfile.likedItinerariesUid.clear()
-            activeProfile.likedItinerariesUid.addAll(itineraries.map { it.uid })
-        }
-    }
-
-    /** Creates a profile from a Firebase user */
-    fun createProfileFromFirebaseUser(user: FirebaseUser): Profile {
-        val uid = user.uid
-        val displayName = user.displayName ?: ""
-        val bio = ""
-
-        return Profile(userUid = uid, displayName = displayName, bio = bio)
-    }
-
-    /** Factory for creating a `ProfileViewModel` */
-    class Factory(
-        private val profileRepository: ProfileRepository,
-        private val imageRepository: ImageRepository
-    ) : ViewModelProvider.Factory {
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            if (modelClass.isAssignableFrom(ProfileViewModel::class.java)) {
-                @Suppress("UNCHECKED_CAST")
-                return ProfileViewModel(profileRepository, imageRepository) as T
-            }
-            throw IllegalArgumentException("Unknown ViewModel class")
-        }
-    }
+  }
 }
-

--- a/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/github/wanderwise_inc/app/viewmodel/ProfileViewModel.kt
@@ -3,6 +3,7 @@ package com.github.wanderwise_inc.app.viewmodel
 import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import com.github.wanderwise_inc.app.data.ImageRepository
 import com.github.wanderwise_inc.app.data.ProfileRepository
 import com.github.wanderwise_inc.app.model.location.Itinerary
@@ -15,116 +16,138 @@ class ProfileViewModel(
     private val profileRepository: ProfileRepository,
     private val imageRepository: ImageRepository
 ) : ViewModel() {
-  private var isSignInComplete = false // set on sign-in success
-  /** The `Profile` of the currently signed-in user. Set on sign-in */
-  private lateinit var activeProfile: Profile
+    private var isSignInComplete = false // set on sign-in success
 
-  /** @return flow of a user profile */
-  fun getProfile(userUid: String): Flow<Profile?> {
-    Log.d("ProfileViewModel", "Fetching profile for user: $userUid")
-    return profileRepository.getProfile(userUid)
-  }
+    /** The `Profile` of the currently signed-in user. Set on sign-in */
+    private lateinit var activeProfile: Profile
 
-  /** @return all profiles in data source */
-  fun getAllProfiles(): Flow<List<Profile>> {
-    return profileRepository.getAllProfiles()
-  }
-
-  /** Sets a profile in data source */
-  fun setProfile(profile: Profile) {
-    profileRepository.setProfile(profile)
-  }
-
-  /** Deletes a profile from the data source */
-  fun deleteProfile(profile: Profile) {
-    profileRepository.deleteProfile(profile)
-  }
-
-  /** @return the profile picture of a user as a bitmap flow for asynchronous drawing */
-  fun getProfilePicture(profile: Profile): Flow<Uri?> {
-    return imageRepository.fetchImage("profilePicture/${profile.userUid}")
-  }
-
-  /** @return the default profile picture asset */
-  fun getDefaultProfilePicture(): Flow<Uri?> {
-    return imageRepository.fetchImage("profilePicture/defaultProfilePicture.jpg")
-  }
-
-  /**
-   * Adds a liked `Itinerary` to the `Profile` with user-uid `userUid` except if this is the default
-   * offline profile, in which case this call has no effect
-   */
-  fun addLikedItinerary(userUid: String, itineraryUid: String) {
-    if (userUid == DEFAULT_OFFLINE_PROFILE.userUid) return
-    profileRepository.addItineraryToLiked(userUid, itineraryUid)
-  }
-
-  /**
-   * Removes a liked `Itinerary` from the `Profile` with user-uid `userUid` except if this is the
-   * default offline profile, in which case this call has no effect
-   */
-  fun removeLikedItinerary(userUid: String, itineraryUid: String) {
-    if (userUid == DEFAULT_OFFLINE_PROFILE.userUid) return
-    profileRepository.removeItineraryFromLiked(userUid, itineraryUid)
-  }
-
-  /**
-   * @return `true` iff the itinerary with uid `itineraryUid` is liked by the profile with user-uid
-   *   `userUid`
-   */
-  suspend fun checkIfItineraryIsLiked(userUid: String, itineraryUid: String): Boolean {
-    if (userUid == DEFAULT_OFFLINE_PROFILE.userUid) return false
-    return profileRepository.checkIfItineraryIsLiked(userUid, itineraryUid)
-  }
-
-  /** @return `true` iff the itinerary with uid `itineraryUid` is liked by the active profile */
-  suspend fun checkIfItineraryIsLikedByActiveProfile(itineraryUid: String): Boolean {
-    return if (isSignInComplete)
-        profileRepository.checkIfItineraryIsLiked(getUserUid(), itineraryUid)
-    else false
-  }
-
-  /**
-   * @return all of the profile's liked itineraries, or an empty list if there is no actively signed
-   *   in profile
-   */
-  fun getLikedItineraries(userUid: String): Flow<List<String>> {
-    return profileRepository.getLikedItineraries(userUid)
-  }
-
-  /** Sets the active profile. Called on sign-in and only called once */
-  fun setActiveProfile(profile: Profile) {
-    if (!isSignInComplete) {
-      Log.d("ProfileViewModel", "Setting active profile to: $profile")
-      activeProfile = profile
-      isSignInComplete = true
+    init {
+        Log.d("ProfileViewModel", "ProfileViewModel created")
     }
-  }
 
-  /**
-   * @return the profile of the active user, as initialized at sign-in. If sign-in in was
-   *   unsuccessful, this will return `DEFAULT_OFFLINE_PROFILE` as defined in `Profile.kt`
-   */
-  fun getActiveProfile(): Profile = activeProfile
-
-  /** @return the UID of the signed in profile */
-  fun getUserUid(): String = activeProfile.userUid
-
-  /** Updates liked itineraries of active profile locally */
-  fun setActiveProfileLikedItineraries(itineraries: List<Itinerary>) {
-    if (itineraries.isNotEmpty()) {
-      Log.d("ProfileViewModel", "Updating active profile liked: ${itineraries.map { it.uid }}")
-      activeProfile.likedItinerariesUid.clear()
-      activeProfile.likedItinerariesUid.addAll(itineraries.map { it.uid })
+    /** @return flow of a user profile */
+    fun getProfile(userUid: String): Flow<Profile?> {
+        Log.d("ProfileViewModel", "Fetching profile for user: $userUid")
+        return profileRepository.getProfile(userUid)
     }
-  }
 
-  /** Creates a profile from a Firebase user */
-  fun createProfileFromFirebaseUser(user: FirebaseUser): Profile {
-    val uid = user.uid
-    val displayName = user.displayName ?: ""
-    val bio = ""
+    /** @return all profiles in data source */
+    fun getAllProfiles(): Flow<List<Profile>> {
+        return profileRepository.getAllProfiles()
+    }
 
-    return Profile(userUid = uid, displayName = displayName, bio = bio)
-  }
+    /** Sets a profile in data source */
+    fun setProfile(profile: Profile) {
+        profileRepository.setProfile(profile)
+    }
+
+    /** Deletes a profile from the data source */
+    fun deleteProfile(profile: Profile) {
+        profileRepository.deleteProfile(profile)
+    }
+
+    /** @return the profile picture of a user as a bitmap flow for asynchronous drawing */
+    fun getProfilePicture(profile: Profile): Flow<Uri?> {
+        return imageRepository.fetchImage("profilePicture/${profile.userUid}")
+    }
+
+    /** @return the default profile picture asset */
+    fun getDefaultProfilePicture(): Flow<Uri?> {
+        return imageRepository.fetchImage("profilePicture/defaultProfilePicture.jpg")
+    }
+
+    /**
+     * Adds a liked `Itinerary` to the `Profile` with user-uid `userUid` except if this is the default
+     * offline profile, in which case this call has no effect
+     */
+    fun addLikedItinerary(userUid: String, itineraryUid: String) {
+        if (userUid == DEFAULT_OFFLINE_PROFILE.userUid) return
+        profileRepository.addItineraryToLiked(userUid, itineraryUid)
+    }
+
+    /**
+     * Removes a liked `Itinerary` from the `Profile` with user-uid `userUid` except if this is the
+     * default offline profile, in which case this call has no effect
+     */
+    fun removeLikedItinerary(userUid: String, itineraryUid: String) {
+        if (userUid == DEFAULT_OFFLINE_PROFILE.userUid) return
+        profileRepository.removeItineraryFromLiked(userUid, itineraryUid)
+    }
+
+    /**
+     * @return `true` iff the itinerary with uid `itineraryUid` is liked by the profile with user-uid
+     *   `userUid`
+     */
+    suspend fun checkIfItineraryIsLiked(userUid: String, itineraryUid: String): Boolean {
+        if (userUid == DEFAULT_OFFLINE_PROFILE.userUid) return false
+        return profileRepository.checkIfItineraryIsLiked(userUid, itineraryUid)
+    }
+
+    /** @return `true` iff the itinerary with uid `itineraryUid` is liked by the active profile */
+    suspend fun checkIfItineraryIsLikedByActiveProfile(itineraryUid: String): Boolean {
+        return if (isSignInComplete)
+            profileRepository.checkIfItineraryIsLiked(getUserUid(), itineraryUid)
+        else false
+    }
+
+    /**
+     * @return all of the profile's liked itineraries, or an empty list if there is no actively signed
+     *   in profile
+     */
+    fun getLikedItineraries(userUid: String): Flow<List<String>> {
+        return profileRepository.getLikedItineraries(userUid)
+    }
+
+    /** Sets the active profile. Called on sign-in and only called once */
+    fun setActiveProfile(profile: Profile) {
+        if (!isSignInComplete) {
+            activeProfile = profile
+            isSignInComplete = true
+        }
+    }
+
+    /**
+     * @return the profile of the active user, as initialized at sign-in. If sign-in in was
+     *   unsuccessful, this will return `DEFAULT_OFFLINE_PROFILE` as defined in `Profile.kt`
+     */
+    fun getActiveProfile(): Profile = activeProfile
+
+    /** @return the UID of the signed in profile */
+    fun getUserUid(): String = activeProfile.userUid
+
+    /** Updates liked itineraries of active profile locally */
+    fun setActiveProfileLikedItineraries(itineraries: List<Itinerary>) {
+        if (itineraries.isNotEmpty()) {
+            Log.d(
+                "ProfileViewModel",
+                "Updating active profile liked: ${itineraries.map { it.uid }}"
+            )
+            activeProfile.likedItinerariesUid.clear()
+            activeProfile.likedItinerariesUid.addAll(itineraries.map { it.uid })
+        }
+    }
+
+    /** Creates a profile from a Firebase user */
+    fun createProfileFromFirebaseUser(user: FirebaseUser): Profile {
+        val uid = user.uid
+        val displayName = user.displayName ?: ""
+        val bio = ""
+
+        return Profile(userUid = uid, displayName = displayName, bio = bio)
+    }
+
+    /** Factory for creating a `ProfileViewModel` */
+    class Factory(
+        private val profileRepository: ProfileRepository,
+        private val imageRepository: ImageRepository
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(ProfileViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return ProfileViewModel(profileRepository, imageRepository) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
 }
+


### PR DESCRIPTION
- `MainActivity.onCreate()` was being recalled when device rotated to landscape mode
- Since `activeProfile`, a lateinit property, was being set by the sign-in screen which is only accessed once, the app was crashing due to the uninitialized lateinit property.

This PR fixes the aforementioned issue by locking the app orientation in portrait mode. Not only does this fix the bug, but we also believe that it works better for our app as a whole - which like something like instagram, was not designed with landscape mode in mind.